### PR TITLE
task: Deploy UI in GH Pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: NODE_ENV=development BASE_URL=rhtas-console-ui npm run build
+        run: NODE_ENV=development BASE_URL=/rhtas-console-ui/ npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,46 @@
+name: Deploy to GH Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  workflow_call:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  gh-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: NODE_ENV=development BASE_URL=rhtas-console-ui npm run build
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./client/dist"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -10,7 +10,7 @@ import "@patternfly/patternfly/patternfly-addons.css";
 
 const App: React.FC = () => {
   return (
-    <Router>
+    <Router basename={import.meta.env.BASE_URL}>
       <DefaultLayout>
         <AppRoutes />
       </DefaultLayout>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -19,6 +19,7 @@ const faviconPath = path.resolve(brandingPath, "favicon.ico");
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: process.env.BASE_URL,
   plugins: [
     react(),
     {

--- a/common/rollup.config.js
+++ b/common/rollup.config.js
@@ -23,7 +23,7 @@ const stringModule = ejs.render(
   export default strings;
 `,
   {
-    brandingRoot: "branding",
+    brandingRoot: process.env.BASE_URL ? `${process.env.BASE_URL}/branding` : "branding",
   }
 );
 


### PR DESCRIPTION
This PR allows the deployment of the current UI in GH Pages so users can see what the UI looks like.

- This is how it looks like in my own fork https://carlosthe19916.github.io/rhtas-console-ui/
- This is the build that generated the gh page https://github.com/carlosthe19916/rhtas-console-ui/actions/runs/16074974141

Task to do in a separate PR:
- Setup Tanstack Query to provide mock data so we simulate real networks data transaction. However for now it should be fine to render our UI as it only contains mock data so far

## Summary by Sourcery

Enable deployment of the console UI to GitHub Pages by parameterizing asset paths with a BASE_URL and introducing a dedicated CI workflow

New Features:
- Add support for deploying the UI to GitHub Pages

Enhancements:
- Configure Router basename, Rollup brandingRoot, and Vite base using the BASE_URL environment variable

Deployment:
- Add a GitHub Actions workflow to build and deploy the UI to GitHub Pages on pushes to main