### PR TITLE
feat: Add Certificates Tab to the Trust Root Page

### DIFF
--- a/client/src/app/components/ErrorEmptyState.tsx
+++ b/client/src/app/components/ErrorEmptyState.tsx
@@ -3,7 +3,7 @@ import type React from "react";
 import { EmptyState, EmptyStateBody, EmptyStateVariant } from "@patternfly/react-core";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 
-export const StateError: React.FC = () => {
+export const ErrorEmptyState: React.FC = () => {
   return (
     <EmptyState
       status="danger"

--- a/client/src/app/components/FilterToolbar/FilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/FilterControl.tsx
@@ -1,0 +1,10 @@
+import type { FilterValue } from "@app/hooks/TableControls/filtering/types";
+
+export interface IFilterControlProps<TFilterCategoryKey extends string> {
+  categoryKey: TFilterCategoryKey;
+  categoryName: string;
+  filterValue: FilterValue;
+  setFilterValue: (newValue: FilterValue) => void;
+  showToolbarItem?: boolean;
+  isDisabled?: boolean;
+}

--- a/client/src/app/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/components/FilterToolbar/FilterToolbar.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+
+import { Dropdown, DropdownItem, MenuToggle, ToolbarItem, ToolbarToggleGroup } from "@patternfly/react-core";
+import { FilterIcon } from "@patternfly/react-icons";
+
+import type { IFilterCategory } from "@app/hooks/TableControls/filtering/types";
+
+export interface IFilterToolbarProps<TItem, TFilterCategoryKey extends string> {
+  currentFilterCategoryKey?: TFilterCategoryKey;
+  setCurrentFilterCategoryKey: (value: TFilterCategoryKey) => void;
+  categoryTitles: Record<TFilterCategoryKey, string>;
+  filterCategories: IFilterCategory<TItem, TFilterCategoryKey>[];
+  showFilterDropdown?: boolean;
+  isDisabled?: boolean;
+  children?: React.ReactNode;
+}
+
+export const FilterToolbar = <TItem, TFilterCategoryKey extends string>({
+  currentFilterCategoryKey,
+  setCurrentFilterCategoryKey,
+  filterCategories,
+  categoryTitles,
+  showFilterDropdown,
+  isDisabled,
+  children,
+}: IFilterToolbarProps<TItem, TFilterCategoryKey>) => {
+  const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = React.useState(false);
+
+  const onCategorySelect = (category: IFilterCategory<TItem, TFilterCategoryKey>) => {
+    setCurrentFilterCategoryKey(category.categoryKey);
+    setIsCategoryDropdownOpen(false);
+  };
+
+  const currentFilterCategory = filterCategories.find((category) => category.categoryKey === currentFilterCategoryKey);
+
+  const renderDropdownItems = () => {
+    return filterCategories.map((category) => (
+      <DropdownItem
+        id={`filter-category-${category.categoryKey}`}
+        key={category.categoryKey}
+        onClick={() => onCategorySelect(category)}
+      >
+        {categoryTitles[category.categoryKey]}
+      </DropdownItem>
+    ));
+  };
+
+  return (
+    <ToolbarToggleGroup
+      variant="filter-group"
+      toggleIcon={<FilterIcon />}
+      breakpoint="2xl"
+      gap={showFilterDropdown ? { default: "gapMd" } : undefined}
+    >
+      {showFilterDropdown && (
+        <ToolbarItem>
+          <Dropdown
+            toggle={(toggleRef) => (
+              <MenuToggle
+                id="filtered-by"
+                ref={toggleRef}
+                onClick={() => setIsCategoryDropdownOpen(!isCategoryDropdownOpen)}
+                isDisabled={isDisabled}
+              >
+                <FilterIcon /> {currentFilterCategory ? categoryTitles[currentFilterCategory.categoryKey] : null}
+              </MenuToggle>
+            )}
+            isOpen={isCategoryDropdownOpen}
+          >
+            {renderDropdownItems()}
+          </Dropdown>
+        </ToolbarItem>
+      )}
+      {children}
+    </ToolbarToggleGroup>
+  );
+};

--- a/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -1,0 +1,325 @@
+import React from "react";
+
+import {
+  Badge,
+  Button,
+  Label,
+  MenuToggle,
+  type MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+  type SelectOptionProps,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  ToolbarFilter,
+  type ToolbarLabel,
+} from "@patternfly/react-core";
+import { TimesIcon } from "@patternfly/react-icons";
+
+import type { IFilterControlProps } from "./FilterControl";
+
+export interface FilterSelectOptionProps {
+  optionProps?: SelectOptionProps;
+  value: string;
+  label?: string;
+  chipLabel?: string;
+  groupLabel?: string;
+}
+
+export interface IMultiselectFilterControlProps<TFilterCategoryKey extends string>
+  extends IFilterControlProps<TFilterCategoryKey> {
+  /** The full set of options to select from for this filter. */
+  selectOptions: FilterSelectOptionProps[];
+  placeholderText: string;
+  isScrollable?: boolean;
+}
+
+const NO_RESULTS = "no-results";
+
+export const MultiselectFilterControl = <TFilterCategoryKey extends string>({
+  categoryKey,
+  categoryName,
+  filterValue,
+  setFilterValue,
+  showToolbarItem,
+  isDisabled = false,
+  selectOptions,
+  placeholderText,
+  isScrollable = false,
+}: React.PropsWithChildren<IMultiselectFilterControlProps<TFilterCategoryKey>>): JSX.Element | null => {
+  const [isFilterDropdownOpen, setIsFilterDropdownOpen] = React.useState(false);
+  const [inputValue, setInputValue] = React.useState<string>("");
+  const textInputRef = React.useRef<HTMLInputElement>();
+
+  const idPrefix = `filter-control-${categoryKey}`;
+  const withPrefix = (id: string) => `${idPrefix}-${id}`;
+  const defaultGroup = categoryName;
+
+  const filteredOptions = selectOptions.filter(({ label, value, groupLabel }) =>
+    [label ?? value, groupLabel]
+      .reduce((prev, current) => {
+        if (current) {
+          prev.push(current);
+        }
+        return prev;
+      }, [] as string[])
+      .map((it) => it.toLocaleLowerCase())
+      .some((it) => it.includes(inputValue?.trim().toLowerCase() ?? ""))
+  );
+
+  const [firstGroup, ...otherGroups] = [
+    ...new Set([
+      ...(selectOptions
+        ?.map(({ groupLabel }) => groupLabel)
+        .reduce((prev, current) => {
+          if (current) {
+            prev.push(current);
+          }
+          return prev;
+        }, [] as string[]) ?? []),
+      defaultGroup,
+    ]),
+  ];
+
+  const onFilterClearGroup = (groupName: string) =>
+    setFilterValue(
+      filterValue
+        ?.map((filter): [string, FilterSelectOptionProps | undefined] => [
+          filter,
+          selectOptions?.find(({ value }) => filter === value),
+        ])
+        .filter(([, option]) => option)
+        .map(([filter, { groupLabel = defaultGroup } = {}]) => [filter, groupLabel])
+        .filter(([, groupLabel]) => groupLabel !== groupName)
+        .map(([filter]) => filter)
+    );
+  const onFilterClear = (chip: string | ToolbarLabel) => {
+    const value = typeof chip === "string" ? chip : chip.key;
+
+    if (value) {
+      const newValue = filterValue?.filter((val) => val !== value) ?? [];
+      setFilterValue(newValue.length > 0 ? newValue : null);
+    }
+  };
+
+  /*
+   * Note: Create chips only as `ToolbarChip` (no plain string)
+   */
+  const chipsFor = (groupName: string) =>
+    filterValue
+      ?.map((filter) =>
+        selectOptions.find(({ value, groupLabel = defaultGroup }) => value === filter && groupLabel === groupName)
+      )
+      .reduce((prev, current) => {
+        if (current) {
+          prev.push(current);
+        }
+        return prev;
+      }, [] as FilterSelectOptionProps[])
+      .map((option) => {
+        const { chipLabel, label, value } = option;
+        const displayValue: string = chipLabel ?? label ?? value ?? "";
+
+        return {
+          key: value,
+          node: displayValue,
+        };
+      });
+
+  const onSelect = (value: string | undefined) => {
+    if (!value || value === NO_RESULTS) {
+      return;
+    }
+
+    const newFilterValue: string[] = filterValue?.includes(value)
+      ? filterValue.filter((item) => item !== value)
+      : [...(filterValue ?? []), value];
+
+    setFilterValue(newFilterValue);
+  };
+
+  const { focusedItemIndex, getFocusedItem, clearFocusedItemIndex, moveFocusedItemIndex } = useFocusHandlers({
+    filteredOptions,
+  });
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (event.key) {
+      case "Enter":
+        if (!isFilterDropdownOpen) {
+          setIsFilterDropdownOpen(true);
+        } else if (getFocusedItem()?.value) {
+          onSelect(getFocusedItem()?.value);
+        }
+        textInputRef?.current?.focus();
+        break;
+      case "Tab":
+      case "Escape":
+        setIsFilterDropdownOpen(false);
+        clearFocusedItemIndex();
+        break;
+      case "ArrowUp":
+      case "ArrowDown":
+        event.preventDefault();
+        if (isFilterDropdownOpen) {
+          moveFocusedItemIndex(event.key);
+        } else {
+          setIsFilterDropdownOpen(true);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+    setInputValue(value);
+    if (!isFilterDropdownOpen) {
+      setIsFilterDropdownOpen(true);
+    }
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      variant="typeahead"
+      onClick={() => {
+        setIsFilterDropdownOpen(!isFilterDropdownOpen);
+      }}
+      isExpanded={isFilterDropdownOpen}
+      isDisabled={isDisabled || !selectOptions.length}
+      isFullWidth
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={inputValue}
+          onClick={() => {
+            setIsFilterDropdownOpen(!isFilterDropdownOpen);
+          }}
+          onChange={onTextInputChange}
+          onKeyDown={onInputKeyDown}
+          id={withPrefix("typeahead-select-input")}
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder={placeholderText}
+          aria-activedescendant={getFocusedItem() ? withPrefix(`option-${focusedItemIndex}`) : undefined}
+          role="combobox"
+          isExpanded={isFilterDropdownOpen}
+          aria-controls={withPrefix("select-typeahead-listbox")}
+        />
+
+        <TextInputGroupUtilities>
+          {!!inputValue && (
+            <Button
+              variant="plain"
+              onClick={() => {
+                setInputValue("");
+                textInputRef?.current?.focus();
+              }}
+              aria-label="Clear input value"
+            >
+              <TimesIcon aria-hidden />
+            </Button>
+          )}
+          {filterValue?.length ? <Badge isRead>{filterValue.length}</Badge> : null}
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  const withGroupPrefix = (group: string) => (group === categoryName ? group : `${categoryName}/${group}`);
+
+  return (
+    <>
+      {
+        <ToolbarFilter
+          id={`${idPrefix}-${firstGroup}`}
+          labels={chipsFor(firstGroup)}
+          deleteLabel={(_, chip) => onFilterClear(chip)}
+          deleteLabelGroup={() => onFilterClearGroup(firstGroup)}
+          categoryName={{ name: firstGroup, key: withGroupPrefix(firstGroup) }}
+          key={withGroupPrefix(firstGroup)}
+          showToolbarItem={showToolbarItem}
+        >
+          <Select
+            isScrollable={isScrollable}
+            aria-label={categoryName}
+            toggle={toggle}
+            selected={filterValue}
+            onOpenChange={(isOpen) => setIsFilterDropdownOpen(isOpen)}
+            onSelect={(_, selection) => onSelect(selection as string)}
+            isOpen={isFilterDropdownOpen}
+          >
+            <SelectList id={withPrefix("select-typeahead-listbox")}>
+              {filteredOptions.map(({ groupLabel, label, value, optionProps = {} }, index) => (
+                <SelectOption
+                  {...optionProps}
+                  {...(!optionProps.isDisabled && { hasCheckbox: true })}
+                  key={value}
+                  id={withPrefix(`option-${index}`)}
+                  value={value}
+                  isFocused={focusedItemIndex === index}
+                  isSelected={filterValue?.includes(value)}
+                >
+                  {!!groupLabel && <Label>{groupLabel}</Label>} {label ?? value}
+                </SelectOption>
+              ))}
+              {filteredOptions.length === 0 && (
+                <SelectOption isDisabled hasCheckbox={false} key={NO_RESULTS} value={NO_RESULTS} isSelected={false}>
+                  {`No results found for "${inputValue}"`}
+                </SelectOption>
+              )}
+            </SelectList>
+          </Select>
+        </ToolbarFilter>
+      }
+      {otherGroups.map((groupName) => (
+        <ToolbarFilter
+          id={`${idPrefix}-${groupName}`}
+          labels={chipsFor(groupName)}
+          deleteLabel={(_, chip) => onFilterClear(chip)}
+          deleteLabelGroup={() => onFilterClearGroup(groupName)}
+          categoryName={{ name: groupName, key: withGroupPrefix(groupName) }}
+          key={withGroupPrefix(groupName)}
+          showToolbarItem={false}
+        >
+          {" "}
+        </ToolbarFilter>
+      ))}
+    </>
+  );
+};
+
+const useFocusHandlers = ({ filteredOptions }: { filteredOptions: FilterSelectOptionProps[] }) => {
+  const [focusedItemIndex, setFocusedItemIndex] = React.useState<number>(0);
+
+  const moveFocusedItemIndex = (key: string) => setFocusedItemIndex(calculateFocusedItemIndex(key));
+
+  const calculateFocusedItemIndex = (key: string): number => {
+    if (!filteredOptions.length) {
+      return 0;
+    }
+
+    if (key === "ArrowUp") {
+      return focusedItemIndex <= 0 ? filteredOptions.length - 1 : focusedItemIndex - 1;
+    }
+
+    if (key === "ArrowDown") {
+      return focusedItemIndex >= filteredOptions.length - 1 ? 0 : focusedItemIndex + 1;
+    }
+    return 0;
+  };
+
+  const getFocusedItem = () =>
+    filteredOptions[focusedItemIndex] && !filteredOptions[focusedItemIndex]?.optionProps?.isDisabled
+      ? filteredOptions[focusedItemIndex]
+      : undefined;
+
+  return {
+    moveFocusedItemIndex,
+    focusedItemIndex,
+    getFocusedItem,
+    clearFocusedItemIndex: () => setFocusedItemIndex(0),
+  };
+};

--- a/client/src/app/components/FilterToolbar/SearchFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/SearchFilterControl.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+
+import { Button, ButtonVariant, InputGroup, SearchInput, TextInput, ToolbarFilter } from "@patternfly/react-core";
+import { SearchIcon } from "@patternfly/react-icons";
+
+import type { IFilterControlProps } from "./FilterControl";
+
+export interface ISearchFilterControlProps<TFilterCategoryKey extends string>
+  extends IFilterControlProps<TFilterCategoryKey> {
+  placeholderText: string;
+  isNumeric?: boolean;
+}
+
+export const SearchFilterControl = <TFilterCategoryKey extends string>({
+  categoryKey,
+  categoryName,
+  filterValue,
+  setFilterValue,
+  showToolbarItem = true,
+  isDisabled = false,
+  placeholderText,
+  isNumeric = false,
+}: React.PropsWithChildren<ISearchFilterControlProps<TFilterCategoryKey>>): JSX.Element | null => {
+  // Keep internal copy of value until submitted by user
+  const [inputValue, setInputValue] = React.useState(filterValue?.[0] ?? "");
+  // Update it if it changes externally
+  React.useEffect(() => {
+    setInputValue(filterValue?.[0] ?? "");
+  }, [filterValue]);
+
+  const onFilterSubmit = () => {
+    const trimmedValue = inputValue.trim();
+    setFilterValue(trimmedValue ? [trimmedValue.replace(/\s+/g, " ")] : []);
+  };
+
+  const id = `${categoryKey}-input`;
+
+  const inputProps = {
+    name: id,
+    onChange: (_: React.FormEvent, value: string) => setInputValue(value),
+    "aria-label": `${categoryName} filter`,
+    value: inputValue,
+    placeholder: placeholderText,
+    onKeyDown: (event: React.KeyboardEvent) => {
+      if (event.key && event.key !== "Enter") return;
+      onFilterSubmit();
+    },
+    isDisabled: isDisabled,
+  };
+
+  return (
+    <ToolbarFilter
+      labels={filterValue?.map((value) => ({ key: value, node: value })) ?? []}
+      deleteLabel={() => setFilterValue([])}
+      categoryName={categoryName}
+      showToolbarItem={showToolbarItem}
+    >
+      {isNumeric ? (
+        <InputGroup>
+          <TextInput type="number" id="search-input" {...inputProps} />
+          <Button
+            icon={<SearchIcon />}
+            variant={ButtonVariant.control}
+            id="search-button"
+            aria-label="search button for search input"
+            onClick={onFilterSubmit}
+            isDisabled={isDisabled}
+          />
+        </InputGroup>
+      ) : (
+        <SearchInput inputProps={{ id: "search-input" }} {...inputProps} />
+      )}
+    </ToolbarFilter>
+  );
+};

--- a/client/src/app/components/LoadingWrapper.tsx
+++ b/client/src/app/components/LoadingWrapper.tsx
@@ -4,7 +4,7 @@ import type { AxiosError } from "axios";
 
 import { Bullseye, Spinner } from "@patternfly/react-core";
 
-import { StateError } from "./StateError";
+import { ErrorEmptyState } from "./ErrorEmptyState";
 
 export const LoadingWrapper = (props: {
   isFetching: boolean;
@@ -23,7 +23,7 @@ export const LoadingWrapper = (props: {
     );
   }
   if (props.fetchError) {
-    return props.fetchErrorState ? props.fetchErrorState(props.fetchError) : <StateError />;
+    return props.fetchErrorState ? props.fetchErrorState(props.fetchError) : <ErrorEmptyState />;
   }
   return props.children;
 };

--- a/client/src/app/components/SimplePagination.tsx
+++ b/client/src/app/components/SimplePagination.tsx
@@ -1,0 +1,33 @@
+import type React from "react";
+
+import { Pagination, type PaginationProps, PaginationVariant } from "@patternfly/react-core";
+
+export type PaginationStateProps = Pick<
+  PaginationProps,
+  "itemCount" | "perPage" | "page" | "onSetPage" | "onPerPageSelect"
+>;
+
+export interface SimplePaginationProps {
+  paginationProps: PaginationStateProps;
+  isTop: boolean;
+  isCompact?: boolean;
+  noMargin?: boolean;
+  idPrefix?: string;
+}
+
+export const SimplePagination: React.FC<SimplePaginationProps> = ({
+  paginationProps,
+  isTop,
+  isCompact = false,
+  idPrefix = "",
+}) => {
+  return (
+    <Pagination
+      id={`${idPrefix ? `${idPrefix}-` : ""}pagination-${isTop ? "top" : "bottom"}`}
+      variant={isTop ? PaginationVariant.top : PaginationVariant.bottom}
+      isCompact={isCompact}
+      {...paginationProps}
+      widgetId="pagination-id"
+    />
+  );
+};

--- a/client/src/app/components/TableControls/ConditionalTableBody.tsx
+++ b/client/src/app/components/TableControls/ConditionalTableBody.tsx
@@ -1,0 +1,60 @@
+import type React from "react";
+
+import { Bullseye, Spinner } from "@patternfly/react-core";
+import { Tbody, Td, Tr } from "@patternfly/react-table";
+
+import { ErrorEmptyState } from "@app/components/ErrorEmptyState";
+
+import { NoDataEmptyState } from "./NoDataEmptyState";
+
+export interface IConditionalTableBodyProps {
+  numRenderedColumns: number;
+  isLoading?: boolean;
+  isError?: boolean;
+  isNoData?: boolean;
+  errorEmptyState?: React.ReactNode;
+  noDataEmptyState?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const ConditionalTableBody: React.FC<IConditionalTableBodyProps> = ({
+  numRenderedColumns,
+  isLoading = false,
+  isError = false,
+  isNoData = false,
+  errorEmptyState = null,
+  noDataEmptyState = null,
+  children,
+}) => (
+  <>
+    {isLoading ? (
+      <Tbody aria-label="Table loading">
+        <Tr>
+          <Td colSpan={numRenderedColumns}>
+            <Bullseye>
+              <Spinner size="xl" />
+            </Bullseye>
+          </Td>
+        </Tr>
+      </Tbody>
+    ) : isError ? (
+      <Tbody aria-label="Table error">
+        <Tr>
+          <Td colSpan={numRenderedColumns}>
+            <Bullseye>{errorEmptyState ?? <ErrorEmptyState />}</Bullseye>
+          </Td>
+        </Tr>
+      </Tbody>
+    ) : isNoData ? (
+      <Tbody aria-label="Table empty">
+        <Tr>
+          <Td colSpan={numRenderedColumns}>
+            <Bullseye>{noDataEmptyState ?? <NoDataEmptyState />}</Bullseye>
+          </Td>
+        </Tr>
+      </Tbody>
+    ) : (
+      children
+    )}
+  </>
+);

--- a/client/src/app/components/TableControls/NoDataEmptyState.tsx
+++ b/client/src/app/components/TableControls/NoDataEmptyState.tsx
@@ -1,0 +1,11 @@
+import type React from "react";
+
+import { EmptyState, EmptyStateBody, EmptyStateVariant } from "@patternfly/react-core";
+
+export const NoDataEmptyState: React.FC = () => {
+  return (
+    <EmptyState variant={EmptyStateVariant.sm} titleText="No data available" headingLevel="h4" status="info">
+      <EmptyStateBody>No data available to be shown here.</EmptyStateBody>
+    </EmptyState>
+  );
+};

--- a/client/src/app/hooks/TableControls/filtering/getLocalFilterDerivedState.ts
+++ b/client/src/app/hooks/TableControls/filtering/getLocalFilterDerivedState.ts
@@ -1,0 +1,45 @@
+import { getFilterLogicOperator } from "./helpers";
+import type { FilterValue, IFilterCategory, IFilterValues } from "./types";
+
+/**
+ * Args for getLocalFilterDerivedState
+ */
+export interface ILocalFilterDerivedStateArgs<TItem, TFilterCategoryKey extends string> {
+  /**
+   * The data items before filtering
+   */
+  items: TItem[];
+
+  /**
+   * The "source of truth" state for the filter feature (returned by useFilterState)
+   */
+  filterValues: IFilterValues<TFilterCategoryKey>;
+
+  /**
+   * Definitions of the filters to be used
+   */
+  filterCategories?: IFilterCategory<TItem, TFilterCategoryKey>[];
+}
+
+/**
+ * Given the "source of truth" state for the filter feature and additional arguments, returns "derived state" values and convenience functions.
+ * - For local/client-computed tables only. Performs the actual filtering logic, which is done on the server for server-computed tables.
+ */
+export const getLocalFilterDerivedState = <TItem, TFilterCategoryKey extends string>({
+  items,
+  filterCategories = [],
+  filterValues,
+}: ILocalFilterDerivedStateArgs<TItem, TFilterCategoryKey>) => {
+  const filteredItems = items.filter((item) =>
+    Object.entries<FilterValue>(filterValues).every(([filterKey, values]) => {
+      if (!values || values.length === 0) return true;
+      const filterCategory = filterCategories.find((category) => category.categoryKey === filterKey);
+      if (!filterCategory?.matcher) return true;
+      const matcher = filterCategory.matcher;
+      const logicOperator = getFilterLogicOperator(filterCategory) === "AND" ? "every" : "some";
+      return values[logicOperator]((filterValue) => matcher(filterValue, item));
+    })
+  );
+
+  return { filteredItems };
+};

--- a/client/src/app/hooks/TableControls/filtering/helpers.ts
+++ b/client/src/app/hooks/TableControls/filtering/helpers.ts
@@ -1,0 +1,6 @@
+import type { IFilterCategory } from "./types";
+
+export const getFilterLogicOperator = <TItem, TFilterCategoryKey extends string>(
+  filterCategory?: IFilterCategory<TItem, TFilterCategoryKey>,
+  defaultOperator: "AND" | "OR" = "OR"
+) => filterCategory?.logicOperator ?? defaultOperator;

--- a/client/src/app/hooks/TableControls/filtering/types.ts
+++ b/client/src/app/hooks/TableControls/filtering/types.ts
@@ -1,0 +1,18 @@
+export type FilterValue = string[] | undefined | null;
+
+export type IFilterValues<TFilterCategoryKey extends string> = Partial<Record<TFilterCategoryKey, FilterValue>>;
+
+export interface IFilterCategory<
+  /** The actual API objects we're filtering */
+  TItem,
+  TFilterCategoryKey extends string, // Unique identifiers for each filter category (inferred from key properties if possible)
+> {
+  /** For use in the filterValues state object. Must be unique per category. */
+  categoryKey: TFilterCategoryKey;
+
+  /** For client side filtering, provide custom algorithm for testing if the value of `TItem` matches the filter value. */
+  matcher?: (filter: string, item: TItem) => boolean;
+
+  /** How to connect multiple selected options together. Defaults to "AND". */
+  logicOperator?: "AND" | "OR";
+}

--- a/client/src/app/hooks/TableControls/filtering/useFilterPropHelpers.ts
+++ b/client/src/app/hooks/TableControls/filtering/useFilterPropHelpers.ts
@@ -1,0 +1,60 @@
+import type { ToolbarProps } from "@patternfly/react-core";
+
+import type { IFilterToolbarProps } from "@app/components/FilterToolbar/FilterToolbar";
+
+import type { IFilterCategory } from "./types";
+import type { IFilterState } from "./useFilterState";
+
+/**
+ * Args for useFilterPropHelpers that come from outside useTableControlProps
+ */
+export interface IFilterPropHelpersExternalArgs<TItem, TFilterCategoryKey extends string> {
+  /**
+   * The "source of truth" state for the filter feature (returned by useFilterState)
+   */
+  filterState: IFilterState<TFilterCategoryKey>;
+  /**
+   * Definitions of the filters to be used (must include `getItemValue` functions for each category when performing filtering locally)
+   */
+  filterCategories?: IFilterCategory<TItem, TFilterCategoryKey>[];
+
+  currentFilterCategoryKey?: TFilterCategoryKey;
+  setCurrentFilterCategoryKey: (value: TFilterCategoryKey) => void;
+  categoryTitles: Record<TFilterCategoryKey, string>;
+}
+
+/**
+ * Returns derived state and prop helpers for the filter feature based on given "source of truth" state.
+ */
+export const useFilterPropHelpers = <TItem, TFilterCategoryKey extends string>(
+  args: IFilterPropHelpersExternalArgs<TItem, TFilterCategoryKey>
+) => {
+  const {
+    filterState: { setFilterValues },
+    filterCategories = [],
+    currentFilterCategoryKey,
+    setCurrentFilterCategoryKey,
+    categoryTitles,
+  } = args;
+
+  /**
+   * Filter-related props for the PF Toolbar component
+   */
+  const toolbarProps: Omit<ToolbarProps, "ref"> = {
+    collapseListedFiltersBreakpoint: "xl",
+    clearAllFilters: () => setFilterValues({}),
+    clearFiltersButtonText: "Clear all filters",
+  };
+
+  /**
+   * Props for the FilterToolbar component (our component for rendering filters)
+   */
+  const filterToolbarProps: IFilterToolbarProps<TItem, TFilterCategoryKey> = {
+    filterCategories,
+    currentFilterCategoryKey,
+    setCurrentFilterCategoryKey,
+    categoryTitles,
+  };
+
+  return { toolbarProps, filterToolbarProps };
+};

--- a/client/src/app/hooks/TableControls/filtering/useFilterState.ts
+++ b/client/src/app/hooks/TableControls/filtering/useFilterState.ts
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from "react";
+
+import type { IFilterValues } from "./types";
+
+/**
+ * The "source of truth" state for the filter feature.
+ */
+export interface IFilterState<TFilterCategoryKey extends string> {
+  /**
+   * A mapping:
+   * - from string keys uniquely identifying a filterCategory (inferred from the `key` properties of elements in the `filterCategories` array)
+   * - to arrays of strings representing the current value(s) of that filter. Single-value filters are stored as an array with one element.
+   */
+  filterValues: IFilterValues<TFilterCategoryKey>;
+  /**
+   * Updates the `filterValues` mapping.
+   */
+  setFilterValues: (values: IFilterValues<TFilterCategoryKey>) => void;
+}
+
+/**
+ * Args for useFilterState
+ */
+export interface IFilterStateArgs<TFilterCategoryKey extends string> {
+  initialFilterValues?: IFilterValues<TFilterCategoryKey>;
+}
+
+/**
+ * Provides the "source of truth" state for the filter feature.
+ */
+export const useFilterState = <TFilterCategoryKey extends string>(
+  args: IFilterStateArgs<TFilterCategoryKey>
+): IFilterState<TFilterCategoryKey> => {
+  // We need to know if it's the initial load to avoid overwriting changes to the filter values
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+  let initialFilterValues = {};
+
+  if (isInitialLoad) {
+    initialFilterValues = args?.initialFilterValues ?? {};
+  }
+
+  useEffect(() => {
+    if (isInitialLoad) {
+      setIsInitialLoad(false);
+    }
+  }, [isInitialLoad]);
+
+  const [filterValues, setFilterValues] = React.useState<IFilterValues<TFilterCategoryKey>>(initialFilterValues);
+  return { filterValues, setFilterValues };
+};

--- a/client/src/app/hooks/TableControls/pagination/getLocalPaginationDerivedState.ts
+++ b/client/src/app/hooks/TableControls/pagination/getLocalPaginationDerivedState.ts
@@ -1,0 +1,28 @@
+import type { IActivePagination } from "./usePaginationState";
+
+/**
+ * Args for getLocalPaginationDerivedState
+ */
+export interface ILocalPaginationDerivedStateArgs<TItem> {
+  /**
+   * The data items before pagination (but after filtering)
+   */
+  items: TItem[];
+  /**
+   * The "source of truth" state for the pagination feature
+   */
+  activePage: IActivePagination;
+}
+
+/**
+ * Given the "source of truth" state for the pagination feature and additional arguments, returns "derived state" values and convenience functions.
+ * - For local/client-computed tables only. Performs the actual pagination logic, which is done on the server for server-computed tables.
+ */
+export const getLocalPaginationDerivedState = <TItem>({
+  items,
+  activePage: { pageNumber, itemsPerPage },
+}: ILocalPaginationDerivedStateArgs<TItem>) => {
+  const pageStartIndex = (pageNumber - 1) * itemsPerPage;
+  const currentPageItems = items.slice(pageStartIndex, pageStartIndex + itemsPerPage);
+  return { currentPageItems };
+};

--- a/client/src/app/hooks/TableControls/pagination/usePaginationEffects.ts
+++ b/client/src/app/hooks/TableControls/pagination/usePaginationEffects.ts
@@ -1,0 +1,34 @@
+import React from "react";
+
+import type { IPaginationState } from "./usePaginationState";
+
+/**
+ * Args for usePaginationEffects
+ */
+export interface IUsePaginationEffectsArgs {
+  isPaginationEnabled?: boolean;
+  paginationState: IPaginationState;
+  totalItemCount: number;
+  isLoading?: boolean;
+}
+
+/**
+ * Registers side effects necessary to prevent invalid state related to the pagination feature.
+ * - Used internally by usePaginationPropHelpers as part of useTableControlProps
+ * - The effect: When API data updates, if there are fewer total items and the current page no longer exists
+ *   (e.g. you were on page 11 and now the last page is 10), move to the last page of data.
+ */
+export const usePaginationEffects = ({
+  isPaginationEnabled,
+  paginationState: { itemsPerPage, pageNumber, setPageNumber },
+  totalItemCount,
+  isLoading = false,
+}: IUsePaginationEffectsArgs) => {
+  // When items are removed, make sure the current page still exists
+  const lastPageNumber = Math.max(Math.ceil(totalItemCount / itemsPerPage), 1);
+  React.useEffect(() => {
+    if (isPaginationEnabled && pageNumber > lastPageNumber && !isLoading) {
+      setPageNumber(lastPageNumber);
+    }
+  });
+};

--- a/client/src/app/hooks/TableControls/pagination/usePaginationPropHelpers.ts
+++ b/client/src/app/hooks/TableControls/pagination/usePaginationPropHelpers.ts
@@ -1,0 +1,54 @@
+import type { PaginationProps, ToolbarItemProps } from "@patternfly/react-core";
+
+import { type IUsePaginationEffectsArgs, usePaginationEffects } from "./usePaginationEffects";
+import type { IPaginationState } from "./usePaginationState";
+
+/**
+ * Args for usePaginationPropHelpers that come from outside useTableControlProps
+ */
+export type IPaginationPropHelpersExternalArgs = IUsePaginationEffectsArgs & {
+  /**
+   * The "source of truth" state for the pagination feature (returned by usePaginationState)
+   */
+  paginationState: IPaginationState;
+  /**
+    The total number of items in the entire un-filtered, un-paginated table (the size of the entire API collection being tabulated).
+   */
+  totalItemCount: number;
+};
+
+/**
+ * Returns derived state and prop helpers for the pagination feature based on given "source of truth" state.
+ */
+export const usePaginationPropHelpers = (args: IPaginationPropHelpersExternalArgs) => {
+  const {
+    totalItemCount,
+    paginationState: { itemsPerPage, pageNumber, setPageNumber, setItemsPerPage },
+  } = args;
+
+  usePaginationEffects(args);
+
+  /**
+   * Props for the PF Pagination component
+   */
+  const paginationProps: PaginationProps = {
+    itemCount: totalItemCount,
+    perPage: itemsPerPage,
+    page: pageNumber,
+    onSetPage: (_event, pageNumber) => setPageNumber(pageNumber),
+    onPerPageSelect: (_event, perPage) => {
+      setPageNumber(1);
+      setItemsPerPage(perPage);
+    },
+  };
+
+  /**
+   * Props for the PF ToolbarItem component which contains the Pagination component
+   */
+  const paginationToolbarItemProps: ToolbarItemProps = {
+    variant: "pagination",
+    align: { default: "alignEnd" },
+  };
+
+  return { paginationProps, paginationToolbarItemProps };
+};

--- a/client/src/app/hooks/TableControls/pagination/usePaginationState.ts
+++ b/client/src/app/hooks/TableControls/pagination/usePaginationState.ts
@@ -1,0 +1,66 @@
+import React from "react";
+
+/**
+ * The currently applied pagination parameters
+ */
+export interface IActivePagination {
+  /**
+   * The current page number on the user's pagination controls (counting from 1)
+   */
+  pageNumber: number;
+  /**
+   * The current "items per page" setting on the user's pagination controls (defaults to 10)
+   */
+  itemsPerPage: number;
+}
+
+/**
+ * The "source of truth" state for the pagination feature.
+ */
+export interface IPaginationState extends IActivePagination {
+  /**
+   * Updates the current page number on the user's pagination controls (counting from 1)
+   */
+  setPageNumber: (pageNumber: number) => void;
+  /**
+   * Updates the "items per page" setting on the user's pagination controls (defaults to 10)
+   */
+  setItemsPerPage: (numItems: number) => void;
+}
+
+/**
+ * Args for usePaginationState
+ */
+export interface IPaginationStateArgs {
+  /**
+   * The initial value of the "items per page" setting on the user's pagination controls (defaults to 10)
+   */
+  initialItemsPerPage?: number;
+}
+
+/**
+ * Provides the "source of truth" state for the pagination feature.
+ */
+export const usePaginationState = (args?: IPaginationStateArgs): IPaginationState => {
+  const initialItemsPerPage = args?.initialItemsPerPage ?? 10;
+
+  const defaultValue: IActivePagination = {
+    pageNumber: 1,
+    itemsPerPage: initialItemsPerPage,
+  };
+
+  const [paginationState, setPaginationState] = React.useState<IActivePagination | null>(null);
+
+  const { pageNumber, itemsPerPage } = paginationState ?? defaultValue;
+  const setPageNumber = (num: number) =>
+    setPaginationState({
+      pageNumber: num >= 1 ? num : 1,
+      itemsPerPage: paginationState?.itemsPerPage ?? initialItemsPerPage,
+    });
+  const setItemsPerPage = (itemsPerPage: number) =>
+    setPaginationState({
+      pageNumber: paginationState?.pageNumber ?? 1,
+      itemsPerPage,
+    });
+  return { pageNumber, setPageNumber, itemsPerPage, setItemsPerPage };
+};

--- a/client/src/app/hooks/TableControls/sorting/getLocalSortDerivedState.ts
+++ b/client/src/app/hooks/TableControls/sorting/getLocalSortDerivedState.ts
@@ -1,0 +1,49 @@
+import { universalComparator } from "@app/utils/utils";
+import type { ISortState } from "./useSortState";
+
+/**
+ * Args for getLocalSortDerivedState
+ */
+export interface ILocalSortDerivedStateArgs<TItem, TSortableColumnKey extends string> {
+  /**
+   * The data items before sorting
+   */
+  items: TItem[];
+
+  /**
+   * The "source of truth" state for the sort feature (returned by useSortState)
+   */
+  activeSort: ISortState<TSortableColumnKey>["activeSort"];
+
+  /**
+   * A callback function to return, for a given API data item, a record of sortable primitives for that item's sortable columns
+   * - The record maps:
+   *   - from `columnKey` values (the keys of the `columnNames` object passed to useTableControlState)
+   *   - to easily sorted primitive values (string | number | boolean) for this item's value in that column
+   */
+  getSortValues?: (item: TItem) => Record<TSortableColumnKey, string | number | boolean>;
+}
+
+/**
+ * Given the "source of truth" state for the sort feature and additional arguments, returns "derived state" values and convenience functions.
+ * - For local/client-computed tables only. Performs the actual sorting logic, which is done on the server for server-computed tables.
+ */
+export const getLocalSortDerivedState = <TItem, TSortableColumnKey extends string>({
+  items,
+  getSortValues,
+  activeSort,
+}: ILocalSortDerivedStateArgs<TItem, TSortableColumnKey>) => {
+  if (!getSortValues || !activeSort) {
+    return { sortedItems: items };
+  }
+
+  let sortedItems = items;
+  sortedItems = [...items].sort((a: TItem, b: TItem) => {
+    const aValue = getSortValues(a)[activeSort.columnKey];
+    const bValue = getSortValues(b)[activeSort.columnKey];
+    const compareValue = universalComparator(aValue, bValue, "en");
+    return activeSort.direction === "asc" ? compareValue : -compareValue;
+  });
+
+  return { sortedItems };
+};

--- a/client/src/app/hooks/TableControls/sorting/useSortPropHelpers.ts
+++ b/client/src/app/hooks/TableControls/sorting/useSortPropHelpers.ts
@@ -1,0 +1,55 @@
+import type { ThProps } from "@patternfly/react-table";
+import type { ISortState } from "./useSortState";
+
+/**
+ * Args for useSortPropHelpers that come from outside useTableControlProps
+ */
+export interface ISortPropHelpersExternalArgs<TSortableColumnKey extends string> {
+  /**
+   * The "source of truth" state for the sort feature (returned by useSortState)
+   */
+  sortState: ISortState<TSortableColumnKey>;
+
+  /**
+   * The `columnKey` values (keys of the `columnNames` object passed to useTableControlState) corresponding to columns with sorting enabled
+   */
+  sortableColumns?: TSortableColumnKey[];
+}
+
+/**
+ * Returns derived state and prop helpers for the sort feature based on given "source of truth" state.
+ * - Used internally by useTableControlProps
+ * - "Derived state" here refers to values and convenience functions derived at render time.
+ */
+export const useSortPropHelpers = <TSortableColumnKey extends string>(
+  args: ISortPropHelpersExternalArgs<TSortableColumnKey>
+) => {
+  const {
+    sortState: { activeSort, setActiveSort },
+    sortableColumns = [],
+  } = args;
+
+  /**
+   * Returns props for the Th component for a column with sorting enabled.
+   */
+  const getSortThProps = ({ columnKey }: { columnKey: TSortableColumnKey }): Pick<ThProps, "sort"> =>
+    sortableColumns.includes(columnKey)
+      ? {
+          sort: {
+            columnIndex: sortableColumns.indexOf(columnKey),
+            sortBy: {
+              index: activeSort ? sortableColumns.indexOf(activeSort.columnKey) : undefined,
+              direction: activeSort?.direction,
+            },
+            onSort: (_event, index, direction) => {
+              setActiveSort({
+                columnKey: sortableColumns[index],
+                direction,
+              });
+            },
+          },
+        }
+      : {};
+
+  return { getSortThProps };
+};

--- a/client/src/app/hooks/TableControls/sorting/useSortState.ts
+++ b/client/src/app/hooks/TableControls/sorting/useSortState.ts
@@ -1,0 +1,56 @@
+import React from "react";
+
+/**
+ * The currently applied sort parameters
+ */
+export interface IActiveSort<TSortableColumnKey extends string> {
+  /**
+   * The identifier for the currently sorted column (`columnKey` values come from the keys of the `columnNames` object passed to useTableControlState)
+   */
+  columnKey: TSortableColumnKey;
+  /**
+   * The direction of the currently applied sort (ascending or descending)
+   */
+  direction: "asc" | "desc";
+}
+
+/**
+ * The "source of truth" state for the sort feature.
+ */
+export interface ISortState<TSortableColumnKey extends string> {
+  /**
+   * The currently applied sort column and direction
+   */
+  activeSort: IActiveSort<TSortableColumnKey> | null;
+  /**
+   * Updates the currently applied sort column and direction
+   */
+  setActiveSort: (sort: IActiveSort<TSortableColumnKey>) => void;
+}
+
+/**
+ * Args for useSortState
+ */
+export interface ISortStateArgs<TSortableColumnKey extends string> {
+  /**
+   * The `columnKey` values (keys of the `columnNames` object passed to useTableControlState) corresponding to columns with sorting enabled
+   */
+  sortableColumns: TSortableColumnKey[];
+  /**
+   * The sort column and direction that should be applied by default when the table first loads
+   */
+  initialSort?: IActiveSort<TSortableColumnKey> | null;
+}
+
+/**
+ * Provides the "source of truth" state for the sort feature.
+ */
+export const useSortState = <TSortableColumnKey extends string>(
+  args: ISortStateArgs<TSortableColumnKey>
+): ISortState<TSortableColumnKey> => {
+  const initialSort = args.initialSort ?? null;
+
+  const [activeSort, setActiveSort] = React.useState<IActiveSort<TSortableColumnKey> | null>(initialSort);
+
+  return { activeSort, setActiveSort };
+};

--- a/client/src/app/hooks/TableControls/useLocalTableControlDerivedState.ts
+++ b/client/src/app/hooks/TableControls/useLocalTableControlDerivedState.ts
@@ -1,0 +1,66 @@
+import { useMemo } from "react";
+
+import { getLocalFilterDerivedState } from "./filtering/getLocalFilterDerivedState";
+import type { IFilterCategory, IFilterValues } from "./filtering/types";
+import { getLocalPaginationDerivedState } from "./pagination/getLocalPaginationDerivedState";
+import type { IActivePagination } from "./pagination/usePaginationState";
+import { getLocalSortDerivedState } from "./sorting/getLocalSortDerivedState";
+import type { IActiveSort } from "./sorting/useSortState";
+
+export interface ILocalTableControlDerivedStateArgs<
+  TItem,
+  TFilterCategoryKey extends string,
+  TSortableColumnKey extends string,
+> {
+  items: TItem[];
+  filtering: {
+    filterCategories?: IFilterCategory<TItem, TFilterCategoryKey>[];
+    activeFilters: IFilterValues<TFilterCategoryKey>;
+  };
+  sorting: {
+    getSortValues?: (item: TItem) => Record<TSortableColumnKey, string | number | boolean>;
+    activeSort: IActiveSort<TSortableColumnKey> | null;
+  };
+  pagination: {
+    activePage: IActivePagination;
+  };
+}
+
+export const useLocalTableControlDerivedState = <
+  TItem,
+  TFilterCategoryKey extends string,
+  TSortableColumnKey extends string,
+>({
+  items,
+  filtering,
+  sorting,
+  pagination,
+}: ILocalTableControlDerivedStateArgs<TItem, TFilterCategoryKey, TSortableColumnKey>) => {
+  const { filteredItems } = useMemo(() => {
+    return getLocalFilterDerivedState({
+      items,
+      filterCategories: filtering.filterCategories,
+      filterValues: filtering.activeFilters,
+    });
+  }, [items, filtering]);
+
+  const { sortedItems } = useMemo(() => {
+    return getLocalSortDerivedState({
+      items: filteredItems,
+      ...sorting,
+    });
+  }, [filteredItems, sorting]);
+
+  const { currentPageItems } = useMemo(() => {
+    return getLocalPaginationDerivedState({
+      items: sortedItems,
+      activePage: pagination.activePage,
+    });
+  }, [sortedItems, pagination]);
+
+  return {
+    filteredItems,
+    totalItemCount: filteredItems.length,
+    currentPageItems: currentPageItems,
+  };
+};

--- a/client/src/app/hooks/TableControls/usePFTable.ts
+++ b/client/src/app/hooks/TableControls/usePFTable.ts
@@ -1,0 +1,30 @@
+import { usePaginationPropHelpers } from "./pagination/usePaginationPropHelpers";
+import { useSortPropHelpers } from "./sorting/useSortPropHelpers";
+import { useTable, type ITableArgs } from "./useTable";
+
+export const usePFTable = <TItem, TSortableColumnKey extends string, TFilterCategoryKey extends string>(
+  args: ITableArgs<TItem, TSortableColumnKey, TFilterCategoryKey>
+) => {
+  const tableState = useTable(args);
+
+  const { getSortThProps } = useSortPropHelpers({
+    sortableColumns: args.sorting?.sortableColumns,
+    sortState: tableState.sortingState,
+  });
+
+  const { paginationProps, paginationToolbarItemProps } = usePaginationPropHelpers({
+    paginationState: tableState.paginationState,
+    totalItemCount: tableState.tableState.totalItemCount,
+    isLoading: false,
+    isPaginationEnabled: true,
+  });
+
+  return {
+    ...tableState,
+    propHelpers: {
+      getSortThProps,
+      paginationProps,
+      paginationToolbarItemProps,
+    },
+  };
+};

--- a/client/src/app/hooks/TableControls/useTable.ts
+++ b/client/src/app/hooks/TableControls/useTable.ts
@@ -1,0 +1,59 @@
+import type { IFilterCategory } from "./filtering/types";
+import { useFilterState, type IFilterStateArgs } from "./filtering/useFilterState";
+import { usePaginationState, type IPaginationStateArgs } from "./pagination/usePaginationState";
+import { useSortState, type ISortStateArgs } from "./sorting/useSortState";
+import { useLocalTableControlDerivedState } from "./useLocalTableControlDerivedState";
+
+export interface ITableArgs<TItem, TSortableColumnKey extends string, TFilterCategoryKey extends string> {
+  items: TItem[];
+  filtering?: IFilterStateArgs<TFilterCategoryKey> & {
+    filterCategories?: IFilterCategory<TItem, TFilterCategoryKey>[];
+  };
+  sorting?: ISortStateArgs<TSortableColumnKey> & {
+    getSortValues?: (item: TItem) => Record<TSortableColumnKey, string | number | boolean>;
+  };
+  pagination?: IPaginationStateArgs;
+}
+
+export const useTable = <TItem, TSortableColumnKey extends string, TFilterCategoryKey extends string>({
+  items,
+  filtering,
+  sorting,
+  pagination,
+}: ITableArgs<TItem, TSortableColumnKey, TFilterCategoryKey>) => {
+  const filteringState = useFilterState({
+    initialFilterValues: filtering?.initialFilterValues,
+  });
+
+  const sortingState = useSortState({
+    initialSort: sorting?.initialSort,
+    sortableColumns: sorting?.sortableColumns ?? [],
+  });
+
+  const paginationState = usePaginationState(pagination);
+
+  const tableState = useLocalTableControlDerivedState({
+    items: items,
+    filtering: {
+      filterCategories: filtering?.filterCategories,
+      activeFilters: filteringState.filterValues,
+    },
+    sorting: {
+      getSortValues: sorting?.getSortValues,
+      activeSort: sortingState.activeSort,
+    },
+    pagination: {
+      activePage: {
+        pageNumber: paginationState.pageNumber,
+        itemsPerPage: paginationState.itemsPerPage,
+      },
+    },
+  });
+
+  return {
+    filteringState,
+    sortingState,
+    paginationState,
+    tableState,
+  };
+};

--- a/client/src/app/hooks/ToolbarControls/useFilterControlPropHelpers.ts
+++ b/client/src/app/hooks/ToolbarControls/useFilterControlPropHelpers.ts
@@ -1,0 +1,36 @@
+import type { IFilterControlProps } from "@app/components/FilterToolbar/FilterControl";
+
+import type { FilterValue } from "../TableControls/filtering/types";
+import type { IFilterState } from "../TableControls/filtering/useFilterState";
+
+export interface IFilterControlPropHelpersExternalArgs<TFilterCategoryKey extends string> {
+  filterState: IFilterState<TFilterCategoryKey>;
+  categoryTitles: Record<TFilterCategoryKey, string>;
+}
+
+export const useFilterControlPropHelpers = <TFilterCategoryKey extends string>(
+  args: IFilterControlPropHelpersExternalArgs<TFilterCategoryKey>
+) => {
+  const {
+    filterState: { filterValues, setFilterValues },
+    categoryTitles,
+  } = args;
+
+  const setFilterValue = (categoryKey: TFilterCategoryKey, newValue: FilterValue) =>
+    setFilterValues({ ...filterValues, [categoryKey]: newValue });
+
+  const getFilterControlProps = ({
+    categoryKey,
+  }: {
+    categoryKey: TFilterCategoryKey;
+  }): Omit<IFilterControlProps<TFilterCategoryKey>, "showToolbarItem" | "isDisabled"> => {
+    return {
+      categoryKey,
+      categoryName: categoryTitles[categoryKey],
+      filterValue: filterValues[categoryKey],
+      setFilterValue: (newValue) => setFilterValue(categoryKey, newValue),
+    };
+  };
+
+  return { getFilterControlProps };
+};

--- a/client/src/app/hooks/usePFToolbarTable.ts
+++ b/client/src/app/hooks/usePFToolbarTable.ts
@@ -1,0 +1,47 @@
+import React from "react";
+
+import { useFilterPropHelpers } from "./TableControls/filtering/useFilterPropHelpers";
+import { usePFTable } from "./TableControls/usePFTable";
+import { type ITableArgs } from "./TableControls/useTable";
+import { useFilterControlPropHelpers } from "./ToolbarControls/useFilterControlPropHelpers";
+
+export const usePFToolbarTable = <TItem, TSortableColumnKey extends string, TFilterCategoryKey extends string>(
+  args: ITableArgs<TItem, TSortableColumnKey, TFilterCategoryKey> & {
+    toolbar: {
+      categoryTitles: Record<TFilterCategoryKey, string>;
+    };
+  }
+) => {
+  const [currentFilterCategoryKey, setCurrentFilterCategoryKey] = React.useState(
+    args.filtering?.filterCategories?.[0].categoryKey
+  );
+
+  const { propHelpers, ...tableState } = usePFTable(args);
+
+  const { toolbarProps, filterToolbarProps } = useFilterPropHelpers({
+    filterCategories: args.filtering?.filterCategories,
+    filterState: tableState.filteringState,
+    currentFilterCategoryKey: currentFilterCategoryKey,
+    setCurrentFilterCategoryKey: setCurrentFilterCategoryKey,
+    categoryTitles: args.toolbar.categoryTitles,
+  });
+
+  const { getFilterControlProps } = useFilterControlPropHelpers({
+    filterState: tableState.filteringState,
+    categoryTitles: args.toolbar.categoryTitles,
+  });
+
+  return {
+    ...tableState,
+    propHelpers: {
+      ...propHelpers,
+      toolbarProps,
+      filterToolbarProps: {
+        ...filterToolbarProps,
+        currentFilterCategoryKey,
+        setCurrentFilterCategoryKey,
+      },
+      getFilterControlProps,
+    },
+  };
+};

--- a/client/src/app/pages/TrustRoot/TrustRoot.tsx
+++ b/client/src/app/pages/TrustRoot/TrustRoot.tsx
@@ -6,8 +6,8 @@ import { ExternalLinkAltIcon } from "@patternfly/react-icons";
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
 import { useFetchTrustRootMetadataInfo } from "@app/queries/trust";
 
-import { Certificates } from "./components/Certificates";
 import { RootDetails } from "./components/RootDetails";
+import { Certificates } from "./components/Certificates";
 
 export const TrustRoots: React.FC = () => {
   const { rootMetadataList, isFetching, fetchError } = useFetchTrustRootMetadataInfo();

--- a/client/src/app/pages/TrustRoot/components/Certificates.tsx
+++ b/client/src/app/pages/TrustRoot/components/Certificates.tsx
@@ -1,5 +1,153 @@
 import React from "react";
 
+import type { AxiosError } from "axios";
+import dayjs from "dayjs";
+
+import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
+import type { _Error, CertificateInfo } from "@app/client";
+import { CertificateStatusIcon } from "@app/components/CertificateStatusIcon";
+import { FilterToolbar } from "@app/components/FilterToolbar/FilterToolbar";
+import { MultiselectFilterControl } from "@app/components/FilterToolbar/MultiselectFilterControl";
+import { SearchFilterControl } from "@app/components/FilterToolbar/SearchFilterControl";
+import { SimplePagination } from "@app/components/SimplePagination";
+import { ConditionalTableBody } from "@app/components/TableControls/ConditionalTableBody";
+import { usePFToolbarTable } from "@app/hooks/usePFToolbarTable";
+import { useFetchTrustTargetCertificates } from "@app/queries/trust";
+import { formatDate, stringMatcher } from "@app/utils/utils";
+
 export const Certificates: React.FC = () => {
-  return <>Certificates</>;
+  const { certificates, isFetching, fetchError } = useFetchTrustTargetCertificates();
+
+  return <CerticatesTable certificates={certificates?.data ?? []} isFetching={isFetching} fetchError={fetchError} />;
+};
+
+interface ICerticatesTableProps {
+  certificates: CertificateInfo[];
+  isFetching: boolean;
+  fetchError: AxiosError<_Error> | null;
+}
+
+export const CerticatesTable: React.FC<ICerticatesTableProps> = ({ certificates, isFetching, fetchError }) => {
+  const tableState = usePFToolbarTable({
+    items: certificates,
+    toolbar: {
+      categoryTitles: {
+        search: "Search",
+        status: "Status",
+      },
+    },
+    filtering: {
+      filterCategories: [
+        {
+          categoryKey: "search",
+          matcher: (filterValue, item) => {
+            return stringMatcher(filterValue, item.issuer);
+          },
+        },
+        {
+          categoryKey: "status",
+          matcher: (filterValue, item) => {
+            return filterValue.toLowerCase() === item.status.toLowerCase();
+          },
+        },
+      ],
+    },
+    sorting: {
+      sortableColumns: ["expiration"],
+      initialSort: {
+        columnKey: "expiration",
+        direction: "desc",
+      },
+      getSortValues: (item) => ({
+        expiration: dayjs(item.expiration).valueOf(),
+      }),
+    },
+  });
+
+  const {
+    tableState: { currentPageItems },
+    propHelpers: {
+      getSortThProps,
+      paginationProps,
+      paginationToolbarItemProps,
+      toolbarProps,
+      filterToolbarProps,
+      getFilterControlProps,
+    },
+  } = tableState;
+
+  return (
+    <>
+      <Toolbar {...toolbarProps} aria-label="certificates toolbar">
+        <ToolbarContent>
+          <FilterToolbar {...filterToolbarProps}>
+            <SearchFilterControl
+              {...getFilterControlProps({ categoryKey: "search" })}
+              placeholderText="Search by issuer..."
+            />
+            <MultiselectFilterControl
+              {...getFilterControlProps({ categoryKey: "status" })}
+              selectOptions={[
+                {
+                  value: "active",
+                  label: "Active",
+                },
+                {
+                  value: "expiring",
+                  label: "Expiring",
+                },
+                {
+                  value: "expired",
+                  label: "Expired",
+                },
+              ]}
+              placeholderText="Status"
+            />
+          </FilterToolbar>
+          <ToolbarItem {...paginationToolbarItemProps}>
+            <SimplePagination idPrefix="certificates-table" isTop paginationProps={paginationProps} />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+
+      <Table aria-label="certificates table">
+        <Thead>
+          <Tr>
+            <Th>Issuer</Th>
+            <Th>Subject</Th>
+            <Th>Target</Th>
+            <Th>Type</Th>
+            <Th>Status</Th>
+            <Th {...getSortThProps({ columnKey: "expiration" })}>Expiration</Th>
+          </Tr>
+        </Thead>
+        <ConditionalTableBody
+          isNoData={currentPageItems.length === 0}
+          numRenderedColumns={6}
+          isLoading={isFetching}
+          isError={!!fetchError}
+        >
+          {currentPageItems.map((certificate, rowIndex) => {
+            return (
+              <Tbody key={rowIndex}>
+                <Tr key={rowIndex}>
+                  <Td>{certificate.issuer}</Td>
+                  <Td>{certificate.subject}</Td>
+                  <Td>{certificate.target}</Td>
+                  <Td>{certificate.type}</Td>
+                  <Td>
+                    <CertificateStatusIcon status={certificate.status} /> {certificate.status}
+                  </Td>
+                  <Td>{formatDate(certificate.expiration)}</Td>
+                </Tr>
+              </Tbody>
+            );
+          })}
+        </ConditionalTableBody>
+      </Table>
+      <SimplePagination idPrefix="certificates-table" isTop={false} paginationProps={paginationProps} />
+    </>
+  );
 };

--- a/client/src/app/queries/mocks/trust.mock.ts
+++ b/client/src/app/queries/mocks/trust.mock.ts
@@ -43,7 +43,7 @@ export const trustTargetCertificatesMock: CertificateInfoList = {
     {
       expiration: "2031-10-05 13:56:58 +0000 UTC",
       issuer: "CN=sigstore,O=sigstore.dev",
-      status: "Active",
+      status: "Expiring",
       subject: "CN=sigstore-intermediate,O=sigstore.dev",
       target: "fulcio_intermediate_v1.crt.pem",
       type: "Fulcio",

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -46,3 +46,14 @@ export const universalComparator = (
   }
   return localeNumericCompare(String(a ?? ""), String(b ?? ""), locale);
 };
+
+/**
+ *
+ * @returns false for any falsy value (regardless of the filter value), true if (coerced to string) lowercased value contains lowercased filter value.
+ */
+export const stringMatcher = (filterValue: string, value: string) => {
+  if (!value) return false;
+  const lowerCaseItemValue = value.toLowerCase();
+  const lowerCaseFilterValue = filterValue.toLowerCase();
+  return lowerCaseItemValue.includes(lowerCaseFilterValue);
+};


### PR DESCRIPTION
## Issue
https://issues.redhat.com/browse/SECURESIGN-2693

Depends on https://github.com/securesign/rhtas-console-ui/pull/7

Implements the Certificates Tab from the mockups https://www.figma.com/design/EKv0MwLlftALSiQU83S0Ey/TAS-Console?node-id=0-1&p=f&t=HmvlAZ0qAUamxiOE-0

- Introduces a reusable hook `usePFToolbarTable` for managing tables and toolbars data.


https://github.com/user-attachments/assets/90334ebd-6988-454d-acd2-dc8a3ba8cbfb

## Summary by Sourcery

Implement certificates feature including TrustRoot page with tabs, certificate table UI, and reusable table toolbar hook

New Features:
- Add TrustRoot page with Certificates and Root details tabs
- Implement certificate listing table with filtering, sorting, and pagination
- Introduce usePFToolbarTable hook for reusable table and toolbar state management

Enhancements:
- Refactor formatDate to use dayjs and new RENDER_DATE_FORMAT constant
- Add generic table control hooks and components for filtering, sorting, and pagination
- Introduce utility comparators (universalComparator, localeNumericCompare) and stringMatcher for table operations
- Add PF toolbar filter controls (SearchFilterControl, MultiselectFilterControl) and supportive UI components (ConditionalTableBody, SimplePagination, LoadingWrapper, StateError, StateNoData, CertificateStatusIcon)
- Add sidebar navigation and routing for Trust root page