### PR TITLE
feat: add PEM visualization for certificates

### DIFF
--- a/client/openapi/console.yaml
+++ b/client/openapi/console.yaml
@@ -777,6 +777,9 @@ components:
         expiration:
           type: string
           description: Expiration date and time of the certificate (notAfter).
+        pem:
+          type: string
+          description: Certificate in PEM-encoded format.
       required:
         - subject
         - issuer
@@ -784,6 +787,7 @@ components:
         - status
         - target
         - expiration
+        - pem
     CertificateInfoList:
       type: object
       properties:

--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -3,3 +3,9 @@ import ENV from "./env";
 export const isAuthRequired = ENV.AUTH_REQUIRED !== "false";
 
 export const RENDER_DATE_FORMAT = "MMM DD, YYYY";
+
+/**
+ * The name of the client generated id field inserted in a object marked with mixin type
+ * `WithUiId`.
+ */
+export const UI_UNIQUE_ID = "_ui_unique_id";

--- a/client/src/app/hooks/TableControls/expansion/getExpansionDerivedState.ts
+++ b/client/src/app/hooks/TableControls/expansion/getExpansionDerivedState.ts
@@ -1,0 +1,71 @@
+import type { KeyWithValueType } from "@app/utils/type-utils";
+import type { IExpansionState } from "./useExpansionState";
+
+/**
+ * Args for getExpansionDerivedState
+ */
+export interface IExpansionDerivedStateArgs<TItem, TColumnKey extends string> {
+  /**
+   * The string key/name of a property on the API data item objects that can be used as a unique identifier (string or number)
+   */
+  idProperty: KeyWithValueType<TItem, string | number>;
+  /**
+   * The "source of truth" state for the expansion feature (returned by useExpansionState)
+   */
+  expansionState: IExpansionState<TColumnKey>;
+}
+
+/**
+ * Derived state for the expansion feature
+ * - "Derived state" here refers to values and convenience functions derived at render time based on the "source of truth" state.
+ * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
+ */
+export interface IExpansionDerivedState<TItem, TColumnKey extends string> {
+  /**
+   * Returns whether a cell or a row is expanded
+   *  - If called with a columnKey, returns whether that column's cell in this row is expanded (for compound-expand)
+   *  - If called without a columnKey, returns whether the entire row or any cell in it is expanded (for both single-expand and compound-expand)
+   */
+  isCellExpanded: (item: TItem, columnKey?: TColumnKey) => boolean;
+  /**
+   * Set a cell or a row as expanded or collapsed
+   *  - If called with a columnKey, sets that column's cell in this row expanded or collapsed (for compound-expand)
+   *  - If called without a columnKey, sets the entire row as expanded or collapsed (for single-expand)
+   */
+  setCellExpanded: (args: { item: TItem; isExpanding?: boolean; columnKey?: TColumnKey }) => void;
+}
+
+/**
+ * Given the "source of truth" state for the expansion feature and additional arguments, returns "derived state" values and convenience functions.
+ * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
+ */
+export const getExpansionDerivedState = <TItem, TColumnKey extends string>({
+  idProperty,
+  expansionState: { expandedCells, setExpandedCells },
+}: IExpansionDerivedStateArgs<TItem, TColumnKey>): IExpansionDerivedState<TItem, TColumnKey> => {
+  const isCellExpanded = (item: TItem, columnKey?: TColumnKey) => {
+    return columnKey
+      ? expandedCells[String(item[idProperty])] === columnKey
+      : !!expandedCells[String(item[idProperty])];
+  };
+
+  const setCellExpanded = ({
+    item,
+    isExpanding = true,
+    columnKey,
+  }: {
+    item: TItem;
+    isExpanding?: boolean;
+    columnKey?: TColumnKey;
+  }) => {
+    const newExpandedCells = { ...expandedCells };
+    if (isExpanding) {
+      newExpandedCells[String(item[idProperty])] = columnKey ?? true;
+    } else {
+      delete newExpandedCells[String(item[idProperty])];
+    }
+    setExpandedCells(newExpandedCells);
+  };
+
+  return { isCellExpanded, setCellExpanded };
+};

--- a/client/src/app/hooks/TableControls/expansion/useExpansionPropHelpers.ts
+++ b/client/src/app/hooks/TableControls/expansion/useExpansionPropHelpers.ts
@@ -1,0 +1,101 @@
+import type { TdProps } from "@patternfly/react-table";
+
+import type { KeyWithValueType } from "@app/utils/type-utils";
+import { getExpansionDerivedState } from "./getExpansionDerivedState";
+import type { IExpansionState } from "./useExpansionState";
+
+/**
+ * Args for useExpansionPropHelpers
+ */
+export interface IExpansionPropHelpersExternalArgs<TItem, TColumnKey extends string> {
+  /**
+   * The string key/name of a property on the API data item objects that can be used as a unique identifier (string or number)
+   */
+  idProperty: KeyWithValueType<TItem, string | number>;
+  /**
+   * The "source of truth" state for the expansion feature (returned by useExpansionState)
+   */
+  expansionState: IExpansionState<TColumnKey>;
+}
+
+/**
+ * Additional args for useExpansionPropHelpers that come from logic inside useTableControlProps
+ * @see useTableControlProps
+ */
+export interface IExpansionPropHelpersInternalArgs<TColumnKey extends string> {
+  /**
+   * The keys of the `columnNames` object (unique keys identifying each column).
+   */
+  columnKeys: TColumnKey[];
+}
+
+/**
+ * Returns derived state and prop helpers for the expansion feature based on given "source of truth" state.
+ * - Used internally by useTableControlProps
+ * - "Derived state" here refers to values and convenience functions derived at render time.
+ * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
+ */
+export const useExpansionPropHelpers = <TItem, TColumnKey extends string>(
+  args: IExpansionPropHelpersExternalArgs<TItem, TColumnKey> & IExpansionPropHelpersInternalArgs<TColumnKey>
+) => {
+  const { idProperty, columnKeys } = args;
+
+  const expansionDerivedState = getExpansionDerivedState(args);
+  const { isCellExpanded, setCellExpanded } = expansionDerivedState;
+
+  /**
+   * Returns props for the Td to the left of the data cells which contains each row's expansion toggle button (only for single-expand).
+   */
+  const getSingleExpandButtonTdProps = ({
+    item,
+    rowIndex,
+  }: {
+    item: TItem;
+    rowIndex: number;
+  }): Omit<TdProps, "ref"> => ({
+    expand: {
+      rowIndex,
+      isExpanded: isCellExpanded(item),
+      onToggle: () =>
+        setCellExpanded({
+          item,
+          isExpanding: !isCellExpanded(item),
+        }),
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      expandId: `expandable-row-${item[idProperty]}`,
+    },
+  });
+
+  /**
+   * Returns props for the Td which is a data cell in an expandable column and functions as an expand toggle (only for compound-expand)
+   */
+  const getCompoundExpandTdProps = ({
+    columnKey,
+    item,
+    rowIndex,
+  }: {
+    columnKey: TColumnKey;
+    item: TItem;
+    rowIndex: number;
+  }): Omit<TdProps, "ref"> => ({
+    compoundExpand: {
+      isExpanded: isCellExpanded(item, columnKey),
+      onToggle: () =>
+        setCellExpanded({
+          item,
+          isExpanding: !isCellExpanded(item, columnKey),
+          columnKey,
+        }),
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      expandId: `compound-expand-${item[idProperty]}-${columnKey}`,
+      rowIndex,
+      columnIndex: columnKeys.indexOf(columnKey),
+    },
+  });
+
+  return {
+    expansionDerivedState,
+    getSingleExpandButtonTdProps,
+    getCompoundExpandTdProps,
+  };
+};

--- a/client/src/app/hooks/TableControls/expansion/useExpansionState.ts
+++ b/client/src/app/hooks/TableControls/expansion/useExpansionState.ts
@@ -1,0 +1,49 @@
+import React from "react";
+
+/**
+ * A map of item ids (strings resolved from `item[idProperty]`) to either:
+ * - a `columnKey` if that item's row has a compound-expanded cell
+ * - or a boolean:
+ *   - true if the row is expanded (for single-expand)
+ *   - false if the row and all its cells are collapsed (for both single-expand and compound-expand).
+ */
+export type TExpandedCells<TColumnKey extends string> = Record<string, TColumnKey | boolean>;
+
+/**
+ * The "source of truth" state for the expansion feature.
+ */
+export interface IExpansionState<TColumnKey extends string> {
+  /**
+   * A map of item ids to a `columnKey` or boolean for the current expansion state of that cell/row
+   * @see TExpandedCells
+   */
+  expandedCells: TExpandedCells<TColumnKey>;
+  /**
+   * Updates the `expandedCells` map (replacing the entire map).
+   * - See `expansionDerivedState` for helper functions to expand/collapse individual cells/rows.
+   * @see IExpansionDerivedState
+   */
+  setExpandedCells: (newExpandedCells: TExpandedCells<TColumnKey>) => void;
+}
+
+/**
+ * Args for useExpansionState
+ */
+export interface IExpansionStateArgs {
+  /**
+   * Whether to use single-expand or compound-expand behavior
+   * - "single" for the entire row to be expandable with one toggle.
+   * - "compound" for multiple cells in a row to be expandable with individual toggles.
+   */
+  expandableVariant: "single" | "compound";
+}
+
+/**
+ * Provides the "source of truth" state for the expansion feature.
+ * - Used internally by useTableControlState
+ * - Takes args defined above as well as optional args for persisting state to a configurable storage target.
+ */
+export const useExpansionState = <TColumnKey extends string>(): IExpansionState<TColumnKey> => {
+  const [expandedCells, setExpandedCells] = React.useState<TExpandedCells<TColumnKey>>({});
+  return { expandedCells, setExpandedCells };
+};

--- a/client/src/app/hooks/TableControls/usePFTable.ts
+++ b/client/src/app/hooks/TableControls/usePFTable.ts
@@ -1,11 +1,27 @@
+import type { KeyWithValueType } from "@app/utils/type-utils";
+
+import { useExpansionPropHelpers } from "./expansion/useExpansionPropHelpers";
+import { useExpansionState } from "./expansion/useExpansionState";
 import { usePaginationPropHelpers } from "./pagination/usePaginationPropHelpers";
 import { useSortPropHelpers } from "./sorting/useSortPropHelpers";
 import { useTable, type ITableArgs } from "./useTable";
 
-export const usePFTable = <TItem, TSortableColumnKey extends string, TFilterCategoryKey extends string>(
-  args: ITableArgs<TItem, TSortableColumnKey, TFilterCategoryKey>
+export interface IPFTableArgs<TItem, TColumnKey extends string> {
+  columns: TColumnKey[];
+  idProperty: KeyWithValueType<TItem, string | number>;
+}
+
+export const usePFTable = <
+  TItem,
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey,
+  TFilterCategoryKey extends string,
+>(
+  args: ITableArgs<TItem, TSortableColumnKey, TFilterCategoryKey> & IPFTableArgs<TItem, TColumnKey>
 ) => {
   const tableState = useTable(args);
+
+  const expansionState = useExpansionState<TColumnKey>();
 
   const { getSortThProps } = useSortPropHelpers({
     sortableColumns: args.sorting?.sortableColumns,
@@ -19,12 +35,24 @@ export const usePFTable = <TItem, TSortableColumnKey extends string, TFilterCate
     isPaginationEnabled: true,
   });
 
+  const { expansionDerivedState, getCompoundExpandTdProps, getSingleExpandButtonTdProps } = useExpansionPropHelpers<
+    TItem,
+    TColumnKey
+  >({
+    idProperty: args.idProperty,
+    expansionState,
+    columnKeys: args.columns,
+  });
+
   return {
     ...tableState,
     propHelpers: {
       getSortThProps,
       paginationProps,
       paginationToolbarItemProps,
+      getSingleExpandButtonTdProps,
+      getCompoundExpandTdProps,
     },
+    expansionDerivedState,
   };
 };

--- a/client/src/app/hooks/query-utils.ts
+++ b/client/src/app/hooks/query-utils.ts
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+
+import { UI_UNIQUE_ID } from "@app/Constants";
+
+export type WithUiId<T> = T & { _ui_unique_id: string };
+
+/**
+ * Make a shallow copy of `data` and insert a new `UI_UNIQUE_ID` field in each element
+ * with the output of the `generator` function.  This hook allows generating the needed
+ * UI id field for any object that does not already have a unique id field so the object
+ * can be used with our table selection handlers.
+ *
+ * @returns A shallow copy of `T` with an added `UI_UNIQUE_ID` field.
+ */
+export const useWithUiId = <T>(
+  /** Source data to modify. */
+  data: T[] | undefined,
+  /** Generate the unique id for a specific `T`. */
+  generator: (item: T) => string
+): WithUiId<T>[] => {
+  const result = useMemo(() => {
+    if (!data || data.length === 0) {
+      return [];
+    }
+
+    const dataWithUiId: WithUiId<T>[] = data.map((item) => ({
+      ...item,
+      [UI_UNIQUE_ID]: generator(item),
+    }));
+
+    return dataWithUiId;
+  }, [data, generator]);
+
+  return result;
+};

--- a/client/src/app/hooks/usePFToolbarTable.ts
+++ b/client/src/app/hooks/usePFToolbarTable.ts
@@ -1,16 +1,25 @@
 import React from "react";
 
 import { useFilterPropHelpers } from "./TableControls/filtering/useFilterPropHelpers";
-import { usePFTable } from "./TableControls/usePFTable";
+import { usePFTable, type IPFTableArgs } from "./TableControls/usePFTable";
 import { type ITableArgs } from "./TableControls/useTable";
 import { useFilterControlPropHelpers } from "./ToolbarControls/useFilterControlPropHelpers";
 
-export const usePFToolbarTable = <TItem, TSortableColumnKey extends string, TFilterCategoryKey extends string>(
-  args: ITableArgs<TItem, TSortableColumnKey, TFilterCategoryKey> & {
-    toolbar: {
-      categoryTitles: Record<TFilterCategoryKey, string>;
-    };
-  }
+export interface IPFToolbarTableArgs<TFilterCategoryKey extends string> {
+  toolbar: {
+    categoryTitles: Record<TFilterCategoryKey, string>;
+  };
+}
+
+export const usePFToolbarTable = <
+  TItem,
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey,
+  TFilterCategoryKey extends string,
+>(
+  args: ITableArgs<TItem, TSortableColumnKey, TFilterCategoryKey> &
+    IPFTableArgs<TItem, TColumnKey> &
+    IPFToolbarTableArgs<TFilterCategoryKey>
 ) => {
   const [currentFilterCategoryKey, setCurrentFilterCategoryKey] = React.useState(
     args.filtering?.filterCategories?.[0].categoryKey

--- a/client/src/app/queries/mocks/trust.mock.ts
+++ b/client/src/app/queries/mocks/trust.mock.ts
@@ -39,6 +39,7 @@ export const trustTargetCertificatesMock: CertificateInfoList = {
       subject: "CN=sigstore,O=sigstore.dev",
       target: "fulcio.crt.pem",
       type: "Fulcio",
+      pem: "-----BEGIN CERTIFICATE-----\nMIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAq\nMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIx\nMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUu\nZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSy\nA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0Jcas\ntaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6Nm\nMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYE\nFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2u\nSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJx\nVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uup\nHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==\n-----END CERTIFICATE-----\n",
     },
     {
       expiration: "2031-10-05 13:56:58 +0000 UTC",
@@ -47,6 +48,7 @@ export const trustTargetCertificatesMock: CertificateInfoList = {
       subject: "CN=sigstore-intermediate,O=sigstore.dev",
       target: "fulcio_intermediate_v1.crt.pem",
       type: "Fulcio",
+      pem: "-----BEGIN CERTIFICATE-----\nMIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMw\nKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y\nMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3Jl\nLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7\nXeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxex\nX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92j\nYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRY\nwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQ\nKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCM\nWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9\nTNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ\n-----END CERTIFICATE-----\n",
     },
     {
       expiration: "2031-10-05 13:56:58 +0000 UTC",
@@ -55,6 +57,7 @@ export const trustTargetCertificatesMock: CertificateInfoList = {
       subject: "CN=sigstore,O=sigstore.dev",
       target: "fulcio_v1.crt.pem",
       type: "Fulcio",
+      pem: "-----BEGIN CERTIFICATE-----\nMIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMw\nKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y\nMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3Jl\nLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0C\nAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV7\n7LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS\n0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYB\nBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjp\nKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZI\nzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJR\nnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsP\nmygUY7Ii2zbdCdliiow=\n-----END CERTIFICATE-----\n",
     },
   ],
 };

--- a/client/src/app/utils/type-utils.ts
+++ b/client/src/app/utils/type-utils.ts
@@ -1,0 +1,3 @@
+export type KeyWithValueType<T, V> = {
+  [Key in keyof T]-?: T[Key] extends V ? Key : never;
+}[keyof T];


### PR DESCRIPTION
- This PR adds PEM to the expanded area of the certificates table (Trust Root page).
- Expands the table components to support expandable states

Depends on https://github.com/securesign/rhtas-console-ui/pull/11

## Summary by Sourcery

Enable row expansion in PatternFly tables by introducing new expansion hooks and prop helpers, integrate them into existing table hooks, apply expansion to the Certificates table, and provide a utility for generating unique UI IDs

New Features:
- Add expandable rows support in tables via useExpansionState, useExpansionPropHelpers, and getExpansionDerivedState
- Integrate expansion logic into usePFTable and usePFToolbarTable and enable expandable rows in the Certificates table with placeholder content
- Introduce useWithUiId hook and UI_UNIQUE_ID constant to generate unique client-side identifiers for items

Enhancements:
- Extend usePFTable and usePFToolbarTable interfaces to accept columns and idProperty for expansion
- Add KeyWithValueType type utility for inferring object keys by value type

## Summary by Sourcery

Enable expandable rows in tables and display PEM content for certificates

New Features:
- Add single and compound row expansion support via useExpansionState, useExpansionPropHelpers, and getExpansionDerivedState
- Extend certificates table to show PEM in expandable rows with Copy and Download actions
- Introduce useWithUiId hook and UI_UNIQUE_ID constant for generating unique client-side identifiers

Enhancements:
- Integrate expansion logic into usePFTable and usePFToolbarTable hooks and extend their interfaces to accept columns and idProperty
- Add KeyWithValueType type utility for inferring object keys by value type

Documentation:
- Include `pem` field in CertificateInfo OpenAPI schema

Chores:
- Populate certificate mocks with sample PEM data