### PR TITLE
feat: add overview tab to trust root page

### DIFF
--- a/client/src/app/pages/TrustRoot/TrustRoot.tsx
+++ b/client/src/app/pages/TrustRoot/TrustRoot.tsx
@@ -4,15 +4,27 @@ import { Content, PageSection, Tab, TabContent, Tabs, TabTitleText } from "@patt
 import { ExternalLinkAltIcon } from "@patternfly/react-icons";
 
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
-import { useFetchTrustRootMetadataInfo } from "@app/queries/trust";
+import { useFetchTrustRootMetadataInfo, useFetchTrustTargetCertificates } from "@app/queries/trust";
 
+import { CertificatesTable } from "./components/Certificates";
+import { Overview } from "./components/Overview";
 import { RootDetails } from "./components/RootDetails";
-import { Certificates } from "./components/Certificates";
 
 export const TrustRoots: React.FC = () => {
-  const { rootMetadataList, isFetching, fetchError } = useFetchTrustRootMetadataInfo();
+  const {
+    rootMetadataList,
+    isFetching: isFetchingRootMetadata,
+    fetchError: fetchErrorRootMetadata,
+  } = useFetchTrustRootMetadataInfo();
+
+  const {
+    certificates,
+    isFetching: isFetchingCertificates,
+    fetchError: fetchErrorCertificates,
+  } = useFetchTrustTargetCertificates();
 
   // Tab refs
+  const overviewTabRef = React.createRef<HTMLElement>();
   const certificatesTabRef = React.createRef<HTMLElement>();
   const rootDetailsTabRef = React.createRef<HTMLElement>();
 
@@ -45,12 +57,18 @@ export const TrustRoots: React.FC = () => {
         >
           <Tab
             eventKey={0}
+            title={<TabTitleText>Overview</TabTitleText>}
+            tabContentId="overviewTabSection"
+            tabContentRef={overviewTabRef}
+          />
+          <Tab
+            eventKey={1}
             title={<TabTitleText>Certificates</TabTitleText>}
             tabContentId="certificatesTabSection"
             tabContentRef={certificatesTabRef}
           />
           <Tab
-            eventKey={1}
+            eventKey={2}
             title={<TabTitleText>Root details</TabTitleText>}
             tabContentId="rootDetailsTabSection"
             tabContentRef={rootDetailsTabRef}
@@ -58,11 +76,22 @@ export const TrustRoots: React.FC = () => {
         </Tabs>
       </PageSection>
       <PageSection>
-        <TabContent eventKey={0} id="certificatesTabSection" ref={certificatesTabRef} aria-label="Certificates">
-          <Certificates />
+        <TabContent eventKey={0} id="overviewTabSection" ref={overviewTabRef} aria-label="Overview">
+          <Overview
+            certificates={certificates?.data ?? []}
+            isFetching={isFetchingCertificates}
+            fetchError={fetchErrorCertificates}
+          />
         </TabContent>
-        <TabContent eventKey={1} id="rootDetailsTabSection" ref={rootDetailsTabRef} aria-label="Root details" hidden>
-          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+        <TabContent eventKey={1} id="certificatesTabSection" ref={certificatesTabRef} aria-label="Certificates" hidden>
+          <CertificatesTable
+            certificates={certificates?.data ?? []}
+            isFetching={isFetchingCertificates}
+            fetchError={fetchErrorCertificates}
+          />
+        </TabContent>
+        <TabContent eventKey={2} id="rootDetailsTabSection" ref={rootDetailsTabRef} aria-label="Root details" hidden>
+          <LoadingWrapper isFetching={isFetchingRootMetadata} fetchError={fetchErrorRootMetadata}>
             {rootMetadataList && <RootDetails rootMetadataList={rootMetadataList} />}
           </LoadingWrapper>
         </TabContent>

--- a/client/src/app/pages/TrustRoot/components/Certificates.tsx
+++ b/client/src/app/pages/TrustRoot/components/Certificates.tsx
@@ -26,22 +26,15 @@ import { SimplePagination } from "@app/components/SimplePagination";
 import { ConditionalTableBody } from "@app/components/TableControls/ConditionalTableBody";
 import { useWithUiId } from "@app/hooks/query-utils";
 import { usePFToolbarTable } from "@app/hooks/usePFToolbarTable";
-import { useFetchTrustTargetCertificates } from "@app/queries/trust";
 import { formatDate, stringMatcher } from "@app/utils/utils";
 
-export const Certificates: React.FC = () => {
-  const { certificates, isFetching, fetchError } = useFetchTrustTargetCertificates();
-
-  return <CerticatesTable certificates={certificates?.data ?? []} isFetching={isFetching} fetchError={fetchError} />;
-};
-
-interface ICerticatesTableProps {
+interface ICertificatesTableProps {
   certificates: CertificateInfo[];
   isFetching: boolean;
   fetchError: AxiosError<_Error> | null;
 }
 
-export const CerticatesTable: React.FC<ICerticatesTableProps> = ({ certificates, isFetching, fetchError }) => {
+export const CertificatesTable: React.FC<ICertificatesTableProps> = ({ certificates, isFetching, fetchError }) => {
   const items = useWithUiId(certificates, (item) => `${item.type}-${item.issuer}-${item.subject}-${item.target}`);
 
   const tableState = usePFToolbarTable({
@@ -161,7 +154,6 @@ export const CerticatesTable: React.FC<ICerticatesTableProps> = ({ certificates,
             <Th screenReaderText="Row expansion" />
             <Th>Issuer</Th>
             <Th>Subject</Th>
-            <Th>Issuer</Th>
             <Th>Target</Th>
             <Th>Type</Th>
             <Th>Status</Th>
@@ -171,7 +163,7 @@ export const CerticatesTable: React.FC<ICerticatesTableProps> = ({ certificates,
         </Thead>
         <ConditionalTableBody
           isNoData={currentPageItems.length === 0}
-          numRenderedColumns={6}
+          numRenderedColumns={8}
           isLoading={isFetching}
           isError={!!fetchError}
         >

--- a/client/src/app/pages/TrustRoot/components/Overview.tsx
+++ b/client/src/app/pages/TrustRoot/components/Overview.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+
+import type { AxiosError } from "axios";
+import dayjs from "dayjs";
+
+import { ChartDonut, ChartThemeColor } from "@patternfly/react-charts/victory";
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Divider,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  FlexItem,
+  List,
+  ListItem,
+} from "@patternfly/react-core";
+import { InfoAltIcon } from "@patternfly/react-icons";
+
+import type { _Error, CertificateInfo } from "@app/client";
+import { LoadingWrapper } from "@app/components/LoadingWrapper";
+
+interface IOverviewProps {
+  certificates: CertificateInfo[];
+  isFetching: boolean;
+  fetchError: AxiosError<_Error> | null;
+}
+
+export const Overview: React.FC<IOverviewProps> = ({ certificates, isFetching, fetchError }) => {
+  const chartDonutData = React.useMemo(() => {
+    return certificates.reduce(
+      (prev, current) => {
+        return {
+          ...prev,
+          [current.status]: (prev[current.status] ?? 0) + 1,
+        };
+      },
+      {} as Record<string, number>
+    );
+  }, [certificates]);
+
+  const totalCertificates = React.useMemo(() => {
+    return Object.values(chartDonutData).reduce((prev, current) => prev + current, 0);
+  }, [chartDonutData]);
+
+  const expiringSoonCertificates = React.useMemo(() => {
+    return certificates.reduce((prev, current) => {
+      const daysBeforeExpiration = dayjs().diff(dayjs(current.expiration), "days");
+      if (daysBeforeExpiration >= 0 && daysBeforeExpiration <= 7) {
+        prev.push(current);
+      }
+      return prev;
+    }, [] as CertificateInfo[]);
+  }, [certificates]);
+
+  return (
+    <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+      <Flex direction={{ default: "column", md: "row" }}>
+        <FlexItem alignSelf={{ default: "alignSelfStretch" }} flex={{ md: "flex_1" }}>
+          <Card isPlain>
+            <CardTitle>Certificate health</CardTitle>
+            <CardBody>
+              <div style={{ height: "230px", width: "350px" }}>
+                <ChartDonut
+                  constrainToVisibleArea
+                  data={Object.entries(chartDonutData).map(([key, value]) => ({ x: key, y: value }))}
+                  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                  labels={({ datum }) => `${datum.x}: ${datum.y}`}
+                  legendData={Object.entries(chartDonutData).map(([key, value]) => ({ name: `${key}: ${value}` }))}
+                  legendOrientation="vertical"
+                  legendPosition="right"
+                  name="Certificates"
+                  padding={{
+                    bottom: 20,
+                    left: 20,
+                    right: 140, // Adjusted to accommodate legend
+                    top: 20,
+                  }}
+                  subTitle="Certificates"
+                  title={totalCertificates.toString()}
+                  themeColor={ChartThemeColor.multiOrdered}
+                  width={350}
+                />
+              </div>
+            </CardBody>
+          </Card>
+        </FlexItem>
+        <Divider orientation={{ md: "vertical" }} inset={{ default: "inset3xl" }} />
+        <FlexItem alignSelf={{ default: "alignSelfStretch" }} flex={{ md: "flex_1" }}>
+          <Card isPlain>
+            <CardTitle>Expiring soon</CardTitle>
+            <CardBody>
+              {expiringSoonCertificates.length > 0 ? (
+                <List>
+                  {expiringSoonCertificates.map((item) => (
+                    <ListItem key={`${item.type}-${item.issuer}-${item.subject}-${item.target}`}>
+                      {item.issuer}
+                    </ListItem>
+                  ))}
+                </List>
+              ) : (
+                <EmptyState variant={EmptyStateVariant.xs} icon={InfoAltIcon}>
+                  <EmptyStateBody>There are no certificates expiring soon.</EmptyStateBody>
+                </EmptyState>
+              )}
+            </CardBody>
+          </Card>
+        </FlexItem>
+      </Flex>
+    </LoadingWrapper>
+  );
+};


### PR DESCRIPTION
## Issue
https://issues.redhat.com/browse/SECURESIGN-2739

Adds the overview tab to the trust root page

- Certificate Health donut chart
- Expiring soon:
  - It will show certificates expiring within 7 days.

<img width="1911" height="939" alt="Screenshot From 2025-08-11 10-20-47" src="https://github.com/user-attachments/assets/0079e991-0e76-4ce9-a155-65d65523e3f9" />

## Summary by Sourcery

Introduce an Overview tab in the Trust Root page to provide a high-level summary of certificate statuses and upcoming expirations, while refactoring and renaming the certificate listing component for improved reuse and adjusting the tab order accordingly.

New Features:
- Add an Overview tab to the Trust Root page displaying certificate health and expiring soon sections

Enhancements:
- Fetch and inject trust target certificates into Overview and CertificatesTable components
- Rename and refactor the certificate listing component to CertificatesTable and adjust its column count
- Reorder tabs in TrustRoots to include Overview as the first tab and update tab refs and event keys