### PR TITLE
task: add database and configurations to docker-compose.yaml

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 CONSOLE_IMAGE=quay.io/securesign/rhtas-console@sha256:c822f8e3c95b4ca1c36221fc617a8cd3606ba7073b2df1118861a34a1d20dfc5
 CONSOLE_UI_IMAGE=quay.io/securesign/rhtas-console-ui@sha256:c0b0b2d76548c05efadb2425baf93609cf6c40180f170cb531fbb7689a91db31
+CONSOLE_DB_IMAGE=mariadb:lts-ubi
+

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-CONSOLE_IMAGE=quay.io/securesign/rhtas-console@sha256:c822f8e3c95b4ca1c36221fc617a8cd3606ba7073b2df1118861a34a1d20dfc5
+CONSOLE_IMAGE=quay.io/securesign/rhtas-console@sha256:75966d60ed709af33efd48c53b96ea7b2fcd4608f90ccc56885bf224e34b55f5
 CONSOLE_UI_IMAGE=quay.io/securesign/rhtas-console-ui@sha256:c0b0b2d76548c05efadb2425baf93609cf6c40180f170cb531fbb7689a91db31
 CONSOLE_DB_IMAGE=mariadb:lts-ubi
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       interval: 10s     # how often to check
       timeout: 5s       # max time to wait for one check
       retries: 5        # how many failures before unhealthy
-      start_period: 30s # time to wait before starting checks
+      start_period: 15s # time to wait before starting checks
 
   console:
     image: ${CONSOLE_IMAGE}  

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,12 +2,34 @@ networks:
   console:
 
 services:
+  console-db:
+    image: ${CONSOLE_DB_IMAGE}
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: tuf_trust
+      MYSQL_USER: rootuser
+      MYSQL_PASSWORD: root
+    networks:
+      - console
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-prootpassword"]
+      interval: 10s     # how often to check
+      timeout: 5s       # max time to wait for one check
+      retries: 5        # how many failures before unhealthy
+      start_period: 30s # time to wait before starting checks
+
   console:
     image: ${CONSOLE_IMAGE}  
     ports:
       - "8087:8080"
+    environment:
+      DB_DSN: rootuser:root@tcp(console-db:3306)/tuf_trust
+      TUF_REPO_URL: https://tuf-repo-cdn.sigstore.dev
     networks:
       - console
+    depends_on:
+      console-db:
+        condition: service_healthy
   
   console-ui:
     image: ${CONSOLE_UI_IMAGE}


### PR DESCRIPTION
## Summary by Sourcery

Set up docker-compose by introducing a MySQL database service for the console application and configuring the console service to wait for and connect to the database using DB_DSN and TUF_REPO_URL environment variables

New Features:
- Add console-db MySQL service to docker-compose with environment variables

Enhancements:
- Add healthcheck configuration for console-db service