### PR TITLE
fix: include index on certificate unique identifier

### DIFF
--- a/client/src/app/hooks/query-utils.ts
+++ b/client/src/app/hooks/query-utils.ts
@@ -16,16 +16,16 @@ export const useWithUiId = <T>(
   /** Source data to modify. */
   data: T[] | undefined,
   /** Generate the unique id for a specific `T`. */
-  generator: (item: T) => string
+  generator: (item: T, index: number) => string
 ): WithUiId<T>[] => {
   const result = useMemo(() => {
     if (!data || data.length === 0) {
       return [];
     }
 
-    const dataWithUiId: WithUiId<T>[] = data.map((item) => ({
+    const dataWithUiId: WithUiId<T>[] = data.map((item, index) => ({
       ...item,
-      [UI_UNIQUE_ID]: generator(item),
+      [UI_UNIQUE_ID]: generator(item, index),
     }));
 
     return dataWithUiId;

--- a/client/src/app/pages/TrustRoot/components/Certificates.tsx
+++ b/client/src/app/pages/TrustRoot/components/Certificates.tsx
@@ -35,7 +35,10 @@ interface ICertificatesTableProps {
 }
 
 export const CertificatesTable: React.FC<ICertificatesTableProps> = ({ certificates, isFetching, fetchError }) => {
-  const items = useWithUiId(certificates, (item) => `${item.type}-${item.issuer}-${item.subject}-${item.target}`);
+  const items = useWithUiId(
+    certificates,
+    (item, index) => `${index}-${item.type}-${item.issuer}-${item.subject}-${item.target}`
+  );
 
   const tableState = usePFToolbarTable({
     items,


### PR DESCRIPTION
Ideally we should not rely on "index" to determine the unique identifier of a an element in a array. However, under exceptional cases, like the Certificates page, where all element's fields can be equal, we need to rely on the index of the array. Ideally the backend could also provide a unique identifier for it.

## Summary by Sourcery

Ensure UI unique identifiers incorporate the item's array index to avoid collisions in scenarios with identical data.

Bug Fixes:
- Extend useWithUiId hook to pass the item index into its unique ID generator
- Update CertificatesTable to prefix certificate IDs with their index for guaranteed uniqueness