### PR TITLE
fix: about TAS url

### DIFF
--- a/branding/strings.json
+++ b/branding/strings.json
@@ -7,7 +7,7 @@
   "about": {
     "displayName": "RHTAS Console",
     "imageSrc": "<%= brandingRoot %>/images/masthead-logo.svg",
-    "documentationUrl": "https://pages.rhtas.com/"
+    "documentationUrl": "https://access.redhat.com/products/red-hat-trusted-artifact-signer"
   },
   "masthead": {
     "leftBrand": {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the TAS about page URL in branding strings.json