### PR TITLE
Fix: Description of media type header on artifact page

### DIFF
--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
@@ -57,7 +57,10 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTermHelpText>
-              <Popover isVisible={false} headerContent={<div>Media Type</div>} bodyContent={<div>TODO</div>}>
+              <Popover
+                headerContent={<div>Media Type</div>}
+                bodyContent={<div>Media type of the container image (e.g., OCI manifest type)</div>}
+              >
                 <DescriptionListTermHelpTextButton>Media Type</DescriptionListTermHelpTextButton>
               </Popover>
             </DescriptionListTermHelpText>


### PR DESCRIPTION
This pr is making popover work by adding description to it.

<img width="1418" height="326" alt="Screenshot 2026-04-08 at 15 22 38" src="https://github.com/user-attachments/assets/189c870d-c524-4082-b3f0-73e3c91f6143" />

Description is taken from the openapi specification