### PR TITLE
fix(securesign-3808): add tooltips to Artifacts page

### DIFF
--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.test.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.test.tsx
@@ -148,6 +148,6 @@ describe("ArtifactSummary", () => {
 
     render(<ArtifactSummary artifact={artifact} verification={verification} />);
 
-    expect(screen.getByText("my-team@corp.com")).toBeInTheDocument();
+    expect(screen.getByText("maintainer=my-team@corp.com")).toBeInTheDocument();
   });
 });

--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.test.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.test.tsx
@@ -1,11 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import { ArtifactSummary } from "./ArtifactSummary";
-import type {
-  ImageMetadataResponse,
-  VerifyArtifactResponse,
-  ArtifactSummaryView,
-} from "@app/client";
+import type { ImageMetadataResponse, VerifyArtifactResponse, ArtifactSummaryView } from "@app/client";
 
 const createArtifact = (overrides: Partial<ImageMetadataResponse> = {}): ImageMetadataResponse => ({
   image: "quay.io/test/image",

--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.test.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { ArtifactSummary } from "./ArtifactSummary";
+import type {
+  ImageMetadataResponse,
+  VerifyArtifactResponse,
+  ArtifactSummaryView,
+} from "@app/client";
+
+const createArtifact = (overrides: Partial<ImageMetadataResponse> = {}): ImageMetadataResponse => ({
+  image: "quay.io/test/image",
+  registry: "quay.io",
+  digest: "sha256:abc123",
+  metadata: {
+    mediaType: "application/vnd.oci.image.manifest.v1+json",
+    size: 1024,
+    created: "2024-06-15T10:30:00Z",
+    labels: { maintainer: "test-maintainer" },
+  },
+  ...overrides,
+});
+
+const createVerification = (summaryOverrides: Partial<ArtifactSummaryView> = {}): VerifyArtifactResponse => ({
+  signatures: [],
+  attestations: [],
+  summary: {
+    overallStatus: "verified",
+    identities: [],
+    signatureCount: 1,
+    attestationCount: 0,
+    rekorEntryCount: 1,
+    ...summaryOverrides,
+  },
+  artifact: createArtifact(),
+});
+
+describe("ArtifactSummary", () => {
+  test("renders digest, media type, size, and created fields", () => {
+    const artifact = createArtifact();
+    const verification = createVerification();
+
+    render(<ArtifactSummary artifact={artifact} verification={verification} />);
+
+    expect(screen.getByText("sha256:abc123")).toBeInTheDocument();
+    expect(screen.getByText("application/vnd.oci.image.manifest.v1+json")).toBeInTheDocument();
+    expect(screen.getByText("1024")).toBeInTheDocument();
+  });
+
+  test("renders identity labels when identities are present", () => {
+    const verification = createVerification({
+      identities: [
+        { id: 1, type: "email", value: "user@example.com", source: "san" },
+        { id: 2, type: "uri", value: "https://accounts.google.com", source: "issuer" },
+      ],
+    });
+
+    render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
+
+    expect(screen.getByText("user@example.com")).toBeInTheDocument();
+    expect(screen.getByText("https://accounts.google.com")).toBeInTheDocument();
+  });
+
+  test("renders 'No identity available' when identities are empty", () => {
+    const verification = createVerification({ identities: [] });
+
+    render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
+
+    expect(screen.getByText("No identity available")).toBeInTheDocument();
+  });
+
+  test("renders signature and attestation counts", () => {
+    const verification = createVerification({
+      signatureCount: 3,
+      attestationCount: 2,
+      rekorEntryCount: 5,
+    });
+
+    render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  test("renders time coherence OK with formatted date range", () => {
+    const verification = createVerification({
+      timeCoherence: {
+        status: "ok",
+        minIntegratedTime: "2024-06-15T10:00:00Z",
+        maxIntegratedTime: "2024-06-15T12:00:00Z",
+      },
+    });
+
+    render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
+
+    expect(screen.getByText(/^OK \(/)).toBeInTheDocument();
+  });
+
+  test("renders popover text for unknown time coherence", () => {
+    const verification = createVerification({
+      timeCoherence: {
+        status: "unknown",
+      },
+    });
+
+    render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
+
+    expect(screen.getByText("unknown")).toBeInTheDocument();
+  });
+
+  test("renders time coherence status directly for warning/error", () => {
+    const verification = createVerification({
+      timeCoherence: {
+        status: "warning",
+      },
+    });
+
+    render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
+
+    expect(screen.getByText("warning")).toBeInTheDocument();
+  });
+
+  test("does not render time coherence section when absent", () => {
+    const verification = createVerification({ timeCoherence: undefined });
+
+    render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
+
+    expect(screen.queryByText("Time Coherence")).not.toBeInTheDocument();
+  });
+
+  test("renders help text buttons for description fields", () => {
+    const verification = createVerification();
+
+    render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
+
+    expect(screen.getByText("Digest")).toBeInTheDocument();
+    expect(screen.getByText("Media Type")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Size/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Created/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Signatures/i })).toBeInTheDocument();
+  });
+
+  test("renders maintainer label", () => {
+    const artifact = createArtifact({
+      metadata: {
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        size: 1024,
+        labels: { maintainer: "my-team@corp.com" },
+      },
+    });
+    const verification = createVerification();
+
+    render(<ArtifactSummary artifact={artifact} verification={verification} />);
+
+    expect(screen.getByText("my-team@corp.com")).toBeInTheDocument();
+  });
+});

--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
@@ -33,8 +33,8 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
   const labels = getAllLabels(artifact.metadata.labels);
   const { timeCoherence } = summary;
 
-  const identityList = identities.map((identity, idx) => (
-    <div key={idx}>
+  const identityList = identities.map((identity) => (
+    <div key={identity.value}>
       <Label isCompact>{identity.value}</Label>
     </div>
   ));

--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
@@ -33,6 +33,28 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
   const labels = getAllLabels(artifact.metadata.labels);
   const { timeCoherence } = summary;
 
+  const identityList = identities.map((identity, idx) => (
+    <div key={idx}>
+      <Label isCompact>{identity.value}</Label>
+    </div>
+  ));
+
+  const identitiesUnavailable = (
+    <Popover triggerAction="hover" bodyContent={<div>Artifact was not signed with a certificate</div>}>
+      <p>No identity available</p>
+    </Popover>
+  );
+
+  const unknownTimeCoherence = (
+    <Popover
+      triggerAction="hover"
+      aria-label="hoverable popover for unknown time coherence"
+      bodyContent={<div>No min/max integrated time recorded in transparency log</div>}
+    >
+      <p>{timeCoherence?.status}</p>
+    </Popover>
+  );
+
   const summaryCards = [
     <Card key="artifact-summary" isPlain>
       <CardBody>
@@ -57,18 +79,35 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTermHelpText>
-              <Popover isVisible={false} headerContent={<div>Media Type</div>} bodyContent={<div>TODO</div>}>
+              <Popover
+                headerContent={<div>Media Type</div>}
+                bodyContent={<div>The media type of the container image (e.g., OCI manifest type).</div>}
+              >
                 <DescriptionListTermHelpTextButton>Media Type</DescriptionListTermHelpTextButton>
               </Popover>
             </DescriptionListTermHelpText>
             <DescriptionListDescription>{artifact.metadata.mediaType}</DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
-            <DescriptionListTermHelpText>Size</DescriptionListTermHelpText>
+            <DescriptionListTermHelpText>
+              <Popover
+                headerContent={<div>Size</div>}
+                bodyContent={<div>The size of the container image in bytes.</div>}
+              >
+                <DescriptionListTermHelpTextButton> Size </DescriptionListTermHelpTextButton>
+              </Popover>
+            </DescriptionListTermHelpText>
             <DescriptionListDescription>{artifact.metadata.size}</DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
-            <DescriptionListTermHelpText>Created</DescriptionListTermHelpText>
+            <DescriptionListTermHelpText>
+              <Popover
+                headerContent={<div>Created</div>}
+                bodyContent={<div>The timestamp indicating when the image was created.</div>}
+              >
+                <DescriptionListTermHelpTextButton> Created </DescriptionListTermHelpTextButton>
+              </Popover>
+            </DescriptionListTermHelpText>
             <DescriptionListDescription>{formatDate(artifact.metadata.created)}</DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
@@ -96,18 +135,24 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
                 <DescriptionListTermHelpTextButton> Identities </DescriptionListTermHelpTextButton>
               </Popover>
             </DescriptionListTermHelpText>
-            <DescriptionListDescription>
-              {identities.length
-                ? identities.map((identity, idx) => (
-                    <div key={idx}>
-                      <Label isCompact>{identity.value}</Label>{" "}
-                    </div>
-                  ))
-                : "--"}
+            <DescriptionListDescription style={{ width: "fit-content" }}>
+              {identities.length ? identityList : identitiesUnavailable}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
-            <DescriptionListTermHelpText>Signatures</DescriptionListTermHelpText>
+            <DescriptionListTermHelpText>
+              <Popover
+                headerContent={<div>Signatures</div>}
+                bodyContent={
+                  <div>
+                    The number of cosign signatures attached to this artifact. Each signature is stored as a separate
+                    layer in the OCI registry and can be independently verified.
+                  </div>
+                }
+              >
+                <DescriptionListTermHelpTextButton> Signatures </DescriptionListTermHelpTextButton>
+              </Popover>
+            </DescriptionListTermHelpText>
             <DescriptionListDescription>{summary.signatureCount}</DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
@@ -141,10 +186,12 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
                   <DescriptionListTermHelpTextButton> Time Coherence </DescriptionListTermHelpTextButton>
                 </Popover>
               </DescriptionListTermHelpText>
-              <DescriptionListDescription>
+              <DescriptionListDescription style={{ width: "fit-content" }}>
                 {timeCoherence.status === "ok"
                   ? `OK (${formatDate(timeCoherence.minIntegratedTime)} – ${formatDate(timeCoherence.maxIntegratedTime)})`
-                  : timeCoherence.status}
+                  : timeCoherence.status === "unknown"
+                    ? unknownTimeCoherence
+                    : timeCoherence.status}
               </DescriptionListDescription>
             </DescriptionListGroup>
           )}


### PR DESCRIPTION
When the Artifacts page shows empty or vague values there's no tooltip to explain why.

## Improvements:
Tooltip added to "Identities" explaining why there aren't any:
<img width="1732" height="661" alt="image" src="https://github.com/user-attachments/assets/b3032b3b-5be8-478b-97ec-a26d1242f5c0" />


Tooltip added to "Time Coherence" when value is "unknown":
<img width="1732" height="661" alt="image" src="https://github.com/user-attachments/assets/aca61f11-b96e-4542-af7e-08835110e4bd" />

Updated or added tooltips to other sections:

**size**

<img width="521" height="237" alt="image" src="https://github.com/user-attachments/assets/665f9130-8453-4041-885f-f7595e3d9411" />

**created**

<img width="432" height="237" alt="image" src="https://github.com/user-attachments/assets/2ece0162-9317-495a-ae8c-aae18b489948" />

**signatures**

<img width="432" height="237" alt="image" src="https://github.com/user-attachments/assets/6e619493-9d77-4289-bef6-996bf50aa142" />

JIRA: SECURESIGN-3808