### PR TITLE
fix: Enhance accessibility Artifacts page tooltips

### DIFF
--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.test.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.test.tsx
@@ -150,4 +150,24 @@ describe("ArtifactSummary", () => {
 
     expect(screen.getByText("maintainer=my-team@corp.com")).toBeInTheDocument();
   });
+
+  test("'No identity available' is a focusable button", () => {
+    const verification = createVerification({ identities: [] });
+
+    render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
+
+    expect(screen.getByRole("button", { name: "No identity available" })).toBeInTheDocument();
+  });
+
+  test("'unknown' time coherence is a focusable button", () => {
+    const verification = createVerification({
+      timeCoherence: {
+        status: "unknown",
+      },
+    });
+
+    render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
+
+    expect(screen.getByRole("button", { name: "unknown" })).toBeInTheDocument();
+  });
 });

--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.test.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.test.tsx
@@ -151,15 +151,15 @@ describe("ArtifactSummary", () => {
     expect(screen.getByText("maintainer=my-team@corp.com")).toBeInTheDocument();
   });
 
-  test("'No identity available' is a focusable button", () => {
+  test("'No identity available' is a focusable element", () => {
     const verification = createVerification({ identities: [] });
 
     render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
 
-    expect(screen.getByRole("button", { name: "No identity available" })).toBeInTheDocument();
+    expect(screen.getByTestId("identities-unavailable-span")).toBeInTheDocument();
   });
 
-  test("'unknown' time coherence is a focusable button", () => {
+  test("'unknown' time coherence is a focusable element", () => {
     const verification = createVerification({
       timeCoherence: {
         status: "unknown",
@@ -168,6 +168,6 @@ describe("ArtifactSummary", () => {
 
     render(<ArtifactSummary artifact={createArtifact()} verification={verification} />);
 
-    expect(screen.getByRole("button", { name: "unknown" })).toBeInTheDocument();
+    expect(screen.getByTestId("unknown-time-coherence-span")).toBeInTheDocument();
   });
 });

--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
@@ -43,7 +43,7 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
 
   const identitiesUnavailable = (
     <Tooltip content="Artifact was not signed with a certificate">
-      <Button variant="link" isInline>
+      <Button variant="plain" isInline>
         No identity available
       </Button>
     </Tooltip>
@@ -51,7 +51,7 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
 
   const unknownTimeCoherence = (
     <Tooltip content="No min/max integrated time recorded in transparency log">
-      <Button variant="link" isInline>
+      <Button variant="plain" isInline>
         {timeCoherence?.status}
       </Button>
     </Tooltip>

--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
@@ -1,7 +1,6 @@
 import { formatDate } from "@app/utils/utils";
 import MultiContentCard from "@patternfly/react-component-groups/dist/esm/MultiContentCard";
 import {
-  Button,
   Card,
   CardBody,
   DescriptionList,

--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
@@ -43,17 +43,17 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
 
   const identitiesUnavailable = (
     <Tooltip content="Artifact was not signed with a certificate">
-      <Button variant="plain" isInline>
+      <span data-testid="identities-unavailable-span" tabIndex={0} style={{ cursor: 'help' }}>
         No identity available
-      </Button>
+      </span>
     </Tooltip>
   );
 
   const unknownTimeCoherence = (
     <Tooltip content="No min/max integrated time recorded in transparency log">
-      <Button variant="plain" isInline>
+      <span data-testid="unknown-time-coherence-span" tabIndex={0} style={{ cursor: 'help' }}>
         {timeCoherence?.status}
-      </Button>
+      </span>
     </Tooltip>
   );
 
@@ -121,10 +121,10 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
             <DescriptionListDescription>
               {labels.length
                 ? labels.map((label) => (
-                    <div key={label}>
-                      <Label isCompact>{label}</Label>
-                    </div>
-                  ))
+                  <div key={label}>
+                    <Label isCompact>{label}</Label>
+                  </div>
+                ))
                 : "--"}
             </DescriptionListDescription>
           </DescriptionListGroup>

--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
@@ -1,6 +1,7 @@
 import { formatDate } from "@app/utils/utils";
 import MultiContentCard from "@patternfly/react-component-groups/dist/esm/MultiContentCard";
 import {
+  Button,
   Card,
   CardBody,
   DescriptionList,
@@ -11,6 +12,7 @@ import {
   DescriptionListDescription,
   ClipboardCopy,
   Label,
+  Tooltip,
 } from "@patternfly/react-core";
 import type { ImageMetadataResponse, VerifyArtifactResponse } from "@app/client";
 
@@ -40,19 +42,19 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
   ));
 
   const identitiesUnavailable = (
-    <Popover triggerAction="hover" bodyContent={<div>Artifact was not signed with a certificate</div>}>
-      <p>No identity available</p>
-    </Popover>
+    <Tooltip content="Artifact was not signed with a certificate">
+      <Button variant="link" isInline>
+        No identity available
+      </Button>
+    </Tooltip>
   );
 
   const unknownTimeCoherence = (
-    <Popover
-      triggerAction="hover"
-      aria-label="hoverable popover for unknown time coherence"
-      bodyContent={<div>No min/max integrated time recorded in transparency log</div>}
-    >
-      <p>{timeCoherence?.status}</p>
-    </Popover>
+    <Tooltip content="No min/max integrated time recorded in transparency log">
+      <Button variant="link" isInline>
+        {timeCoherence?.status}
+      </Button>
+    </Tooltip>
   );
 
   const summaryCards = [

--- a/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
+++ b/client/src/app/pages/Artifacts/components/ArtifactSummary.tsx
@@ -43,7 +43,7 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
 
   const identitiesUnavailable = (
     <Tooltip content="Artifact was not signed with a certificate">
-      <span data-testid="identities-unavailable-span" tabIndex={0} style={{ cursor: 'help' }}>
+      <span data-testid="identities-unavailable-span" tabIndex={0} style={{ cursor: "help" }}>
         No identity available
       </span>
     </Tooltip>
@@ -51,7 +51,7 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
 
   const unknownTimeCoherence = (
     <Tooltip content="No min/max integrated time recorded in transparency log">
-      <span data-testid="unknown-time-coherence-span" tabIndex={0} style={{ cursor: 'help' }}>
+      <span data-testid="unknown-time-coherence-span" tabIndex={0} style={{ cursor: "help" }}>
         {timeCoherence?.status}
       </span>
     </Tooltip>
@@ -121,10 +121,10 @@ export const ArtifactSummary = ({ artifact, verification }: IArtifactSummaryProp
             <DescriptionListDescription>
               {labels.length
                 ? labels.map((label) => (
-                  <div key={label}>
-                    <Label isCompact>{label}</Label>
-                  </div>
-                ))
+                    <div key={label}>
+                      <Label isCompact>{label}</Label>
+                    </div>
+                  ))
                 : "--"}
             </DescriptionListDescription>
           </DescriptionListGroup>


### PR DESCRIPTION
Enhance the accessbility of the new tooltips in the Artifacts page. They are now accessible using the keyboard (Tab).

**Demo:**

https://github.com/user-attachments/assets/399a8a00-07b8-40bb-95c4-a2aa1c3774d6





JIRA: SECURESIGN-3808