### PR TITLE
Fix: RekorSearch: Cached results persist after changing Rekor endpoint in Settings

### DIFF
--- a/client/src/app/queries/rekor-search.ts
+++ b/client/src/app/queries/rekor-search.ts
@@ -1,23 +1,25 @@
 import { useQuery } from "@tanstack/react-query";
-import { useRekorClient } from "@app/pages/Rekor/shared/utils/rekor/api/context";
+import { useRekorBaseUrl, useRekorClient } from "@app/pages/Rekor/shared/utils/rekor/api/context";
 import { type SearchQuery, useRekorSearch } from "@app/pages/Rekor/shared/utils/rekor/api/rekor-api";
 
 export const RekorKey = "Rekor";
 
 export const useFetchRekorEntry = (logIndex: string) => {
   const client = useRekorClient();
+  const [baseUrl] = useRekorBaseUrl();
 
   return useQuery({
-    queryKey: [RekorKey, "entry", logIndex, client.entries],
+    queryKey: [RekorKey, "entry", logIndex, client.entries, baseUrl],
     queryFn: () => client.entries.getLogEntryByIndex({ logIndex: Number(logIndex) }),
   });
 };
 
 export const useFetchRekorSearch = (query: SearchQuery | undefined, page: number) => {
   const search = useRekorSearch();
+  const [baseUrl] = useRekorBaseUrl();
 
   return useQuery({
-    queryKey: [RekorKey, "search", query, page, search],
+    queryKey: [RekorKey, "search", query, page, search, baseUrl],
     queryFn: () => search(query!, page),
     enabled: !!query,
   });


### PR DESCRIPTION
This pr is trying to resolve this issue:

https://redhat.atlassian.net/browse/SECURESIGN-4306

Simply added `baseUrl` from `useRekorBaseUrl` to dependencies of the queries to fix the issue with cached results on different endpoints