### PR TITLE
fix: validate Rekor certificate validity at integratedTime

### DIFF
--- a/client/src/app/pages/Rekor/RekorEntry/components/Entry.tsx
+++ b/client/src/app/pages/Rekor/RekorEntry/components/Entry.tsx
@@ -173,7 +173,12 @@ export function Entry({ entry }: { entry: LogEntry }) {
             <CardTitle>Public Key Certificate</CardTitle>
           </CardHeader>
           <CardBody>
-            <PublicKey type={body.kind} apiVersion={body.apiVersion} spec={body.spec} integratedTime={obj.integratedTime} />
+            <PublicKey
+              type={body.kind}
+              apiVersion={body.apiVersion}
+              spec={body.spec}
+              integratedTime={obj.integratedTime}
+            />
           </CardBody>
         </Card>
       </FlexItem>

--- a/client/src/app/pages/Rekor/RekorEntry/components/Entry.tsx
+++ b/client/src/app/pages/Rekor/RekorEntry/components/Entry.tsx
@@ -173,12 +173,7 @@ export function Entry({ entry }: { entry: LogEntry }) {
             <CardTitle>Public Key Certificate</CardTitle>
           </CardHeader>
           <CardBody>
-            <PublicKey
-              type={body.kind}
-              apiVersion={body.apiVersion}
-              spec={body.spec}
-              integratedTime={obj.integratedTime}
-            />
+            <PublicKey type={body.kind} apiVersion={body.apiVersion} spec={body.spec} />
           </CardBody>
         </Card>
       </FlexItem>

--- a/client/src/app/pages/Rekor/RekorEntry/components/Entry.tsx
+++ b/client/src/app/pages/Rekor/RekorEntry/components/Entry.tsx
@@ -173,7 +173,7 @@ export function Entry({ entry }: { entry: LogEntry }) {
             <CardTitle>Public Key Certificate</CardTitle>
           </CardHeader>
           <CardBody>
-            <PublicKey type={body.kind} apiVersion={body.apiVersion} spec={body.spec} />
+            <PublicKey type={body.kind} apiVersion={body.apiVersion} spec={body.spec} integratedTime={obj.integratedTime} />
           </CardBody>
         </Card>
       </FlexItem>

--- a/client/src/app/pages/Rekor/RekorSearch/components/RekorList.tsx
+++ b/client/src/app/pages/Rekor/RekorSearch/components/RekorList.tsx
@@ -221,6 +221,7 @@ export function RekorList({
                       spec={row.body.spec}
                       type={row.body.kind}
                       variant="validity"
+                      integratedTime={row.integratedTime}
                     />
                   </Td>
                   <Td dataLabel="Integrated time">{formatIntegratedTime(row.integratedTime)}</Td>

--- a/client/src/app/pages/Rekor/shared/components/PublicKey.tsx
+++ b/client/src/app/pages/Rekor/shared/components/PublicKey.tsx
@@ -6,14 +6,16 @@ export function PublicKey({
   spec,
   apiVersion,
   variant = "content",
+  integratedTime,
 }: {
   type: string;
   apiVersion: string;
   spec: unknown;
   variant?: "content" | "validity";
+  integratedTime?: number;
 }) {
   if (variant === "validity") {
-    return <PublicKeyValidity isValid={isPublicKeyValid({ type, spec, apiVersion })} />;
+    return <PublicKeyValidity isValid={isPublicKeyValid({ type, spec, apiVersion }, integratedTime)} />;
   }
 
   const content = getPublicKeyContent({ type, spec, apiVersion });

--- a/client/src/app/pages/Rekor/shared/utils/spec.test.ts
+++ b/client/src/app/pages/Rekor/shared/utils/spec.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { isPublicKeyValid } from "./spec";
+
+// Mock the x509 decode module
+vi.mock("./x509/decode", () => ({
+  hasValidPublicCertificate: vi.fn(),
+}));
+
+import { hasValidPublicCertificate } from "./x509/decode";
+
+describe("isPublicKeyValid", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("hashedrekord and rekord types", () => {
+    it("validates certificate for hashedrekord type", () => {
+      const spec = {
+        data: { hash: { algorithm: "sha256", value: "abc123" } },
+        signature: {
+          content: "signature-content",
+          publicKey: { content: window.btoa("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----") },
+        },
+      };
+
+      vi.mocked(hasValidPublicCertificate).mockReturnValue(true);
+
+      const result = isPublicKeyValid({ type: "hashedrekord", spec, apiVersion: "0.0.1" });
+
+      expect(hasValidPublicCertificate).toHaveBeenCalledWith(
+        "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+        undefined
+      );
+      expect(result).toBe(true);
+    });
+
+    it("passes integratedTime to certificate validation for hashedrekord", () => {
+      const spec = {
+        data: { hash: { algorithm: "sha256", value: "abc123" } },
+        signature: {
+          content: "signature-content",
+          publicKey: { content: window.btoa("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----") },
+        },
+      };
+
+      vi.mocked(hasValidPublicCertificate).mockReturnValue(true);
+      const integratedTime = 1710504600; // Unix timestamp for 2024-03-15
+
+      const result = isPublicKeyValid({ type: "hashedrekord", spec, apiVersion: "0.0.1" }, integratedTime);
+
+      expect(hasValidPublicCertificate).toHaveBeenCalledWith(
+        "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+        integratedTime
+      );
+      expect(result).toBe(true);
+    });
+
+    it("validates certificate for rekord type", () => {
+      const spec = {
+        data: { hash: { algorithm: "sha256", value: "abc123" } },
+        signature: {
+          content: "signature-content",
+          publicKey: { content: window.btoa("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----") },
+        },
+      };
+
+      vi.mocked(hasValidPublicCertificate).mockReturnValue(true);
+
+      const result = isPublicKeyValid({ type: "rekord", spec, apiVersion: "0.0.1" });
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("intoto types", () => {
+    it("validates certificate for intoto v0.0.1", () => {
+      const spec = {
+        publicKey: window.btoa("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
+        content: {},
+      };
+
+      vi.mocked(hasValidPublicCertificate).mockReturnValue(true);
+
+      const result = isPublicKeyValid({ type: "intoto", spec, apiVersion: "0.0.1" });
+
+      expect(hasValidPublicCertificate).toHaveBeenCalledWith(
+        "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+        undefined
+      );
+      expect(result).toBe(true);
+    });
+
+    it("validates certificate for intoto v0.0.2 with integratedTime", () => {
+      const spec = {
+        content: {
+          envelope: {
+            signatures: [
+              {
+                sig: "signature",
+                publicKey: window.btoa("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
+              },
+            ],
+          },
+        },
+      };
+
+      vi.mocked(hasValidPublicCertificate).mockReturnValue(true);
+      const integratedTime = 1710504600;
+
+      const result = isPublicKeyValid({ type: "intoto", spec, apiVersion: "0.0.2" }, integratedTime);
+
+      expect(hasValidPublicCertificate).toHaveBeenCalledWith(
+        "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+        integratedTime
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("dsse type", () => {
+    it("validates certificate for dsse type", () => {
+      const spec = {
+        signatures: [
+          {
+            verifier: window.btoa("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
+            signature: "signature-content",
+          },
+        ],
+      };
+
+      vi.mocked(hasValidPublicCertificate).mockReturnValue(true);
+
+      const result = isPublicKeyValid({ type: "dsse", spec, apiVersion: "0.0.1" });
+
+      expect(hasValidPublicCertificate).toHaveBeenCalledWith(
+        "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+        undefined
+      );
+      expect(result).toBe(true);
+    });
+
+    it("passes integratedTime to certificate validation for dsse", () => {
+      const spec = {
+        signatures: [
+          {
+            verifier: window.btoa("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
+            signature: "signature-content",
+          },
+        ],
+      };
+
+      vi.mocked(hasValidPublicCertificate).mockReturnValue(true);
+      const integratedTime = 1710504600;
+
+      const result = isPublicKeyValid({ type: "dsse", spec, apiVersion: "0.0.1" }, integratedTime);
+
+      expect(hasValidPublicCertificate).toHaveBeenCalledWith(
+        "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+        integratedTime
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns false when certificate content is missing", () => {
+      const spec = {
+        data: { hash: { algorithm: "sha256", value: "abc123" } },
+        signature: {
+          content: "signature-content",
+          publicKey: {},
+        },
+      };
+
+      // When content is undefined, window.atob("") returns empty string
+      // which doesn't include "BEGIN CERTIFICATE", so hasValidPublicCertificate returns false
+      vi.mocked(hasValidPublicCertificate).mockReturnValue(false);
+
+      const result = isPublicKeyValid({ type: "hashedrekord", spec, apiVersion: "0.0.1" });
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when hasValidPublicCertificate returns false", () => {
+      const spec = {
+        data: { hash: { algorithm: "sha256", value: "abc123" } },
+        signature: {
+          content: "signature-content",
+          publicKey: { content: window.btoa("invalid-cert") },
+        },
+      };
+
+      vi.mocked(hasValidPublicCertificate).mockReturnValue(false);
+
+      const result = isPublicKeyValid({ type: "hashedrekord", spec, apiVersion: "0.0.1" });
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false for unsupported type", () => {
+      const spec = {};
+
+      const result = isPublicKeyValid({ type: "unknown-type", spec, apiVersion: "0.0.1" });
+
+      expect(result).toBe(false);
+      expect(hasValidPublicCertificate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/app/pages/Rekor/shared/utils/spec.ts
+++ b/client/src/app/pages/Rekor/shared/utils/spec.ts
@@ -100,8 +100,8 @@ export function getPublicKeyContent(input: SpecInput): string | null {
   return certContent;
 }
 
-export function isPublicKeyValid(input: SpecInput): boolean {
+export function isPublicKeyValid(input: SpecInput, integratedTime?: number): boolean {
   const certContent = getRawPublicKeyCert(input);
   if (certContent == null) return false;
-  return hasValidPublicCertificate(certContent);
+  return hasValidPublicCertificate(certContent, integratedTime);
 }

--- a/client/src/app/pages/Rekor/shared/utils/x509/decode.test.ts
+++ b/client/src/app/pages/Rekor/shared/utils/x509/decode.test.ts
@@ -59,7 +59,7 @@ vi.mock("./extensions", () => ({
 }));
 
 // Import after mocks are set up
-import { decodex509 } from "./decode";
+import { decodex509, hasValidPublicCertificate } from "./decode";
 
 describe("decodex509", () => {
   beforeEach(() => {
@@ -121,5 +121,160 @@ describe("decodex509", () => {
 
     // asserts the hex string format of the ArrayBuffer
     expect(decoded["X509v3 extensions"]["unknownExtensionType (critical)"]).toBe("01:02:03:04");
+  });
+});
+
+describe("hasValidPublicCertificate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns false for non-certificate content (public key only)", () => {
+    const publicKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A...\n-----END PUBLIC KEY-----";
+    expect(hasValidPublicCertificate(publicKey)).toBe(false);
+  });
+
+  it("returns false for expired certificate (current time validation)", () => {
+    // Certificate expired in 2022, current time is 2026
+    mockX509CertificateData = {
+      ...mockX509CertificateData,
+      notBefore: new Date("2020-01-01"),
+      notAfter: new Date("2022-01-01"),
+    };
+
+    const expiredCert = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----";
+    expect(hasValidPublicCertificate(expiredCert)).toBe(false);
+  });
+
+  it("returns true for currently valid certificate (current time validation)", () => {
+    // Certificate valid from 2020 to 2030
+    mockX509CertificateData = {
+      ...mockX509CertificateData,
+      notBefore: new Date("2020-01-01"),
+      notAfter: new Date("2030-01-01"),
+    };
+
+    const validCert = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----";
+    expect(hasValidPublicCertificate(validCert)).toBe(true);
+  });
+
+  it("returns false for not-yet-valid certificate (current time validation)", () => {
+    // Certificate not valid until 2028
+    mockX509CertificateData = {
+      ...mockX509CertificateData,
+      notBefore: new Date("2028-01-01"),
+      notAfter: new Date("2030-01-01"),
+    };
+
+    const futureValidCert = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----";
+    expect(hasValidPublicCertificate(futureValidCert)).toBe(false);
+  });
+
+  it("returns true for historical certificate valid at integratedTime (Rekor entry from 2024)", () => {
+    // Certificate valid from 2024-01-01 to 2024-12-31
+    // Rekor entry created on 2024-03-15 (integratedTime)
+    // Current time is 2026 (certificate expired)
+    mockX509CertificateData = {
+      ...mockX509CertificateData,
+      notBefore: new Date("2024-01-01T00:00:00Z"),
+      notAfter: new Date("2024-12-31T23:59:59Z"),
+    };
+
+    const historicalCert = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----";
+    const integratedTime = Math.floor(new Date("2024-03-15T10:30:00Z").getTime() / 1000); // Unix timestamp
+
+    // Should return true because cert was valid at integratedTime
+    expect(hasValidPublicCertificate(historicalCert, integratedTime)).toBe(true);
+  });
+
+  it("returns false for historical certificate expired before integratedTime", () => {
+    // Certificate valid from 2020-01-01 to 2022-01-01
+    // Rekor entry created on 2024-03-15 (after cert expired)
+    mockX509CertificateData = {
+      ...mockX509CertificateData,
+      notBefore: new Date("2020-01-01T00:00:00Z"),
+      notAfter: new Date("2022-01-01T00:00:00Z"),
+    };
+
+    const expiredCert = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----";
+    const integratedTime = Math.floor(new Date("2024-03-15T10:30:00Z").getTime() / 1000);
+
+    // Should return false because cert was already expired at integratedTime
+    expect(hasValidPublicCertificate(expiredCert, integratedTime)).toBe(false);
+  });
+
+  it("returns false for historical certificate not yet valid at integratedTime", () => {
+    // Certificate valid from 2025-01-01 to 2030-01-01
+    // Rekor entry created on 2024-03-15 (before cert valid)
+    mockX509CertificateData = {
+      ...mockX509CertificateData,
+      notBefore: new Date("2025-01-01T00:00:00Z"),
+      notAfter: new Date("2030-01-01T00:00:00Z"),
+    };
+
+    const futureValidCert = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----";
+    const integratedTime = Math.floor(new Date("2024-03-15T10:30:00Z").getTime() / 1000);
+
+    // Should return false because cert wasn't valid yet at integratedTime
+    expect(hasValidPublicCertificate(futureValidCert, integratedTime)).toBe(false);
+  });
+
+  it("validates against current time when integratedTime is undefined", () => {
+    // Certificate valid from 2020 to 2030
+    mockX509CertificateData = {
+      ...mockX509CertificateData,
+      notBefore: new Date("2020-01-01"),
+      notAfter: new Date("2030-01-01"),
+    };
+
+    const validCert = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----";
+
+    // Without integratedTime, should validate against current time
+    expect(hasValidPublicCertificate(validCert, undefined)).toBe(true);
+  });
+
+  it("handles edge case: certificate valid exactly at integratedTime (notBefore boundary)", () => {
+    const exactStartTime = new Date("2024-03-15T10:30:00Z");
+    mockX509CertificateData = {
+      ...mockX509CertificateData,
+      notBefore: exactStartTime,
+      notAfter: new Date("2025-01-01T00:00:00Z"),
+    };
+
+    const cert = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----";
+    const integratedTime = Math.floor(exactStartTime.getTime() / 1000);
+
+    // Should return true - cert becomes valid exactly at integratedTime
+    expect(hasValidPublicCertificate(cert, integratedTime)).toBe(true);
+  });
+
+  it("handles edge case: certificate valid at exact notAfter boundary", () => {
+    const exactEndTime = new Date("2024-03-15T10:30:00Z");
+    mockX509CertificateData = {
+      ...mockX509CertificateData,
+      notBefore: new Date("2020-01-01T00:00:00Z"),
+      notAfter: exactEndTime,
+    };
+
+    const cert = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----";
+    const integratedTime = Math.floor(exactEndTime.getTime() / 1000);
+
+    // Should return true - cert is still valid at exact notAfter time
+    expect(hasValidPublicCertificate(cert, integratedTime)).toBe(true);
+  });
+
+  it("handles edge case: certificate invalid one second after notAfter", () => {
+    const exactEndTime = new Date("2024-03-15T10:30:00Z");
+    mockX509CertificateData = {
+      ...mockX509CertificateData,
+      notBefore: new Date("2020-01-01T00:00:00Z"),
+      notAfter: exactEndTime,
+    };
+
+    const cert = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----";
+    const integratedTime = Math.floor(exactEndTime.getTime() / 1000) + 1; // One second after expiry
+
+    // Should return false - cert expired one second ago
+    expect(hasValidPublicCertificate(cert, integratedTime)).toBe(false);
   });
 });

--- a/client/src/app/pages/Rekor/shared/utils/x509/decode.tsx
+++ b/client/src/app/pages/Rekor/shared/utils/x509/decode.tsx
@@ -40,7 +40,7 @@ export function decodex509(rawCertificate: string) {
   return decodedCert;
 }
 
-export function hasValidPublicCertificate(decoded: string) {
+export function hasValidPublicCertificate(decoded: string, integratedTime?: number) {
   // Check if it's a certificate (not just a public key)
   if (!decoded.includes("BEGIN CERTIFICATE")) {
     return false;
@@ -48,8 +48,10 @@ export function hasValidPublicCertificate(decoded: string) {
 
   // Try to parse the certificate
   const cert = new X509Certificate(decoded);
-  const now = new Date();
-  if (cert.notBefore > now || cert.notAfter < now) {
+  // For Rekor entries, validate against integratedTime (when entry was created)
+  // For current operations, validate against now
+  const validationDate = integratedTime ? new Date(integratedTime * 1000) : new Date();
+  if (cert.notBefore > validationDate || cert.notAfter < validationDate) {
     return false;
   }
 


### PR DESCRIPTION
This PR addresses a regression for Rekor Search. Rekor transparency log shows historical entries with certificates that may be expired now but were valid when the entry was created. Changed certificate temporal validation to check validity at integratedTime (entry creation timestamp) instead of current time.

Changes:
- hasValidPublicCertificate() accepts optional integratedTime parameter
- isPublicKeyValid() passes integratedTime through to certificate validation
- PublicKey component accepts integratedTime prop
- RekorList and Entry pages pass integratedTime to PublicKey component

Fixes: Historical entries showing "Invalid" certificates in Rekor Search

Jira: https://redhat.atlassian.net/browse/SECURESIGN-4343


### Before

<img width="1528" height="897" alt="Screenshot 2026-04-22 at 2 04 45 PM" src="https://github.com/user-attachments/assets/8375a0dd-00e5-4d4d-9ee8-24afc27a341a" />


### After

<img width="1523" height="889" alt="Screenshot 2026-04-22 at 2 27 53 PM" src="https://github.com/user-attachments/assets/b182a8ca-2fc2-4db7-9337-93b454a4852d" />
