### PR TITLE
chore(ci): switch Codecov to OIDC auth

### DIFF
--- a/.github/workflows/ci-e2e-coverage-template.yaml
+++ b/.github/workflows/ci-e2e-coverage-template.yaml
@@ -169,4 +169,4 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           use_oidc: true
-          flags: e2e-tests
+          flags: e2e

--- a/.github/workflows/ci-e2e-coverage-template.yaml
+++ b/.github/workflows/ci-e2e-coverage-template.yaml
@@ -24,9 +24,10 @@ on:
         type: string
         required: false
         default: ""
-    secrets:
-      codecov_token:
-        required: false
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   check-images:
@@ -142,7 +143,7 @@ jobs:
           done
 
       - name: Tests with coverage
-        working-directory: e2e        
+        working-directory: e2e
         run: |
           PW_TEST_CONNECT_WS_ENDPOINT=ws://localhost:${{ steps.start-rhtas-console.outputs.playwright_port }}/ CONSOLE_UI_URL=http://localhost:3000 npm run test
           ls -la .nyc_output
@@ -167,6 +168,5 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
         with:
-          token: ${{ secrets.codecov_token }}
-          slug: ${{ github.repository_owner }}/rhtas-console-ui
-          flags: e2e
+          use_oidc: true
+          flags: e2e-tests

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -12,6 +12,10 @@ on:
   workflow_call:
   merge_group:
 
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: ci-e2e-${{ github.ref }}
   cancel-in-progress: true
@@ -116,5 +120,3 @@ jobs:
       # Won't be used as for coverage the ui will start in dev mode
       ui_image: ghcr.io/securesign/rhtas-console-ui:pr-test
       server_db_image: docker.io/library/mariadb:10.5
-    secrets:
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage-badge.yaml
+++ b/.github/workflows/coverage-badge.yaml
@@ -43,5 +43,5 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           use_oidc: true
-          flags: unit-tests
+          flags: unit
           directory: client/coverage

--- a/.github/workflows/coverage-badge.yaml
+++ b/.github/workflows/coverage-badge.yaml
@@ -2,12 +2,15 @@ name: Test Coverage
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 permissions:
-  contents: write
+  id-token: write
+  contents: read
 
 jobs:
   test:
@@ -39,7 +42,6 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: ${{ github.repository_owner }}/rhtas-console-ui
-          flags: unit
+          use_oidc: true
+          flags: unit-tests
           directory: client/coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,9 @@ coverage:
         threshold: 5%
         base: auto
         only_pulls: true
+
+flags:
+  unit-tests:
+    carryforward: true
+  e2e-tests:
+    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ coverage:
         only_pulls: true
 
 flags:
-  unit-tests:
+  unit:
     carryforward: true
-  e2e-tests:
+  e2e:
     carryforward: true


### PR DESCRIPTION
## Summary
- Replace legacy `CODECOV_TOKEN` auth with OIDC (`use_oidc: true`) across all coverage workflows
- Define dual flags (`unit`, `e2e`) with `carryforward: true` in `codecov.yml` so partial runs don't erase prior results
- Add `id-token: write` permissions for OIDC authentication

## Files Changed
- `.github/workflows/coverage-badge.yaml` — OIDC auth, flag rename, permission update
- `.github/workflows/ci-e2e-coverage-template.yaml` — OIDC auth, removed token secret, flag rename
- `.github/workflows/ci-e2e.yaml` — removed `CODECOV_TOKEN` pass-through, added OIDC permissions

## Context
Implements [SECURESIGN-4444](https://issues.redhat.com/browse/SECURESIGN-4444) and [SECURESIGN-4445](https://redhat.atlassian.net/browse/SECURESIGN-4445)
Epic: [COVERPORT-197](https://issues.redhat.com/browse/COVERPORT-197)

## Test plan
- [ ] Verify unit test coverage uploads with `unit` flag on a push to `main`
- [ ] Verify E2E coverage uploads with `e2e` flag on a push to `main`
- [ ] Confirm OIDC auth works without `CODECOV_TOKEN` secret
- [ ] Confirm carryforward keeps prior flag results when only one suite runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)