### PR TITLE
fix(e2e): replace expired ttl.sh test image with quay.io

### DIFF
--- a/e2e/tests/pages/artifacts/accessibility.spec.ts
+++ b/e2e/tests/pages/artifacts/accessibility.spec.ts
@@ -12,14 +12,14 @@ test.describe("Artifacts page Accessibility", () => {
 
   test("Page view after search", async ({ page }, testInfo) => {
     const artifactsPage = await ArtifactsPage.build(page);
-    await artifactsPage.searchArtifact("ttl.sh/rhtas/console-test-image");
+    await artifactsPage.searchArtifact("quay.io/rh_ee_kdacosta/console-test-signed:v1");
 
     await runA11yAudit(page, testInfo, { label: "artifacts-search" });
   });
 
   test("Page view after expanding signature", async ({ page }, testInfo) => {
     const artifactsPage = await ArtifactsPage.build(page);
-    await artifactsPage.searchArtifact("ttl.sh/rhtas/console-test-image");
+    await artifactsPage.searchArtifact("quay.io/rh_ee_kdacosta/console-test-signed:v1");
 
     await artifactsPage.expandSignaturesCard();
 
@@ -34,7 +34,7 @@ test.describe("Artifacts page Accessibility", () => {
 
   test("Page view after expanding attestation", async ({ page }, testInfo) => {
     const artifactsPage = await ArtifactsPage.build(page);
-    await artifactsPage.searchArtifact("ttl.sh/rhtas/console-test-image");
+    await artifactsPage.searchArtifact("quay.io/rh_ee_kdacosta/console-test-signed:v1");
 
     await artifactsPage.expandAttestationsCard();
 


### PR DESCRIPTION
## Summary
- Replace expired `ttl.sh/rhtas/console-test-image` with permanent `quay.io/rh_ee_kdacosta/console-test-signed:v1` in artifact accessibility e2e tests
- The ttl.sh image expired, causing the backend to return 500 on `/api/v1/artifacts/image` and `/api/v1/artifacts/verify`, failing all 3 artifact accessibility tests
- The new image is signed on public Sigstore (sigstore.dev) which matches the CI docker-compose TUF config

## Test plan
- [x] CI e2e tests pass with the new image
- [x] Verify backend returns 200 for the new image URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)