### PR TITLE
chore(lint): remove disabled no-inferrable-types and no-unnecessary-type-assertion overrides

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,8 +38,6 @@ export default defineConfig([
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
-      "@typescript-eslint/no-unnecessary-type-assertion": "off",
-      "@typescript-eslint/no-inferrable-types": "off",
       "@typescript-eslint/restrict-template-expressions": "off",
       "react-hooks/rules-of-hooks": "off",
       "react-refresh/only-export-components": "off",


### PR DESCRIPTION
> **Tracking issue:** https://github.com/securesign/rhtas-console-ui/issues/307
> **Task:** Task 7 — TypeScript mechanical cleanup

---

## Summary

Remove two `@typescript-eslint` rule overrides from `eslint.config.mjs`:

- `no-inferrable-types`
- `no-unnecessary-type-assertion`

**Finding:** The codebase already conforms — zero violations found. These rules are active by default in `tseslint.configs.recommended`, so the `"off"` entries were dead config. Config-only change, no source files modified.

## Test plan

- [x] `npm run lint` passes with zero warnings/errors
- [x] `npm run test` — all 41 test files pass (422 tests)
- [x] `npm run build` — production build succeeds