### PR TITLE
chore(lint): enable react-refresh/only-export-components

### DIFF
--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -1,5 +1,13 @@
 export const RENDER_DATE_FORMAT = "MMM DD, YYYY";
 
+export const Paths = {
+  artifacts: "/artifacts",
+  rekorSearch: "/rekor-search",
+  rekorEntry: `/rekor-search/:logIndex`,
+  trustRoot: "/trust-root",
+  monitoringAlerting: "/monitoring",
+} as const;
+
 /**
  * The name of the client generated id field inserted in a object marked with mixin type
  * `WithUiId`.

--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -1,25 +1,18 @@
 import { Suspense, lazy } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { Navigate, useParams, useRoutes } from "react-router-dom";
+import { Navigate, useRoutes } from "react-router-dom";
 
 import { Bullseye, Spinner } from "@patternfly/react-core";
 import { ErrorFallback } from "./components/ErrorFallback";
 import NotFound from "./pages/NotFound";
 import { useFeatureFlags } from "./hooks/useFeatureFlags";
+import { Paths } from "./Constants";
 
 const Artifacts = lazy(() => import("./pages/Artifacts"));
 const TrustRoot = lazy(() => import("./pages/TrustRoot"));
 const RekorSearch = lazy(() => import("./pages/Rekor/RekorSearch"));
 const RekorEntry = lazy(() => import("./pages/Rekor/RekorEntry"));
 const Monitoring = lazy(() => import("./pages/Monitoring"));
-
-export const Paths = {
-  artifacts: "/artifacts",
-  rekorSearch: "/rekor-search",
-  rekorEntry: `/rekor-search/:logIndex`,
-  trustRoot: "/trust-root",
-  monitoringAlerting: "/monitoring",
-} as const;
 
 export const AppRoutes = () => {
   const { features } = useFeatureFlags();
@@ -47,13 +40,4 @@ export const AppRoutes = () => {
       </ErrorBoundary>
     </Suspense>
   );
-};
-
-export const useRouteParams = (pathParam: "logIndex") => {
-  const params = useParams();
-  const value = params[pathParam];
-  if (value === undefined) {
-    throw new Error(`ASSERTION FAILURE: required path parameter not set: ${pathParam}`);
-  }
-  return value;
 };

--- a/client/src/app/hooks/useFeatureFlags.tsx
+++ b/client/src/app/hooks/useFeatureFlags.tsx
@@ -22,6 +22,7 @@ export const FeatureFlagsProvider = ({ children }: { children: ReactNode }) => {
   return <FeatureFlagsContext value={value}>{children}</FeatureFlagsContext>;
 };
 
+// eslint-disable-next-line react-refresh/only-export-components -- co-located provider + hook
 export const useFeatureFlags = () => {
   const context = use(FeatureFlagsContext);
   if (!context) {

--- a/client/src/app/hooks/useRouteParams.ts
+++ b/client/src/app/hooks/useRouteParams.ts
@@ -1,0 +1,10 @@
+import { useParams } from "react-router-dom";
+
+export const useRouteParams = (pathParam: "logIndex") => {
+  const params = useParams();
+  const value = params[pathParam];
+  if (value === undefined) {
+    throw new Error(`ASSERTION FAILURE: required path parameter not set: ${pathParam}`);
+  }
+  return value;
+};

--- a/client/src/app/layout/sidebar.tsx
+++ b/client/src/app/layout/sidebar.tsx
@@ -4,7 +4,7 @@ import { NavLink } from "react-router-dom";
 import { Nav, NavList, PageSidebar, PageSidebarBody } from "@patternfly/react-core";
 import { css } from "@patternfly/react-styles";
 import nav from "@patternfly/react-styles/css/components/Nav/nav";
-import { Paths } from "@app/Routes";
+import { Paths } from "@app/Constants";
 import { useFeatureFlags } from "@app/hooks/useFeatureFlags";
 
 const LINK_CLASS = nav.navLink;

--- a/client/src/app/pages/Rekor/RekorEntry/RekorEntry.tsx
+++ b/client/src/app/pages/Rekor/RekorEntry/RekorEntry.tsx
@@ -14,7 +14,8 @@ import {
 } from "@patternfly/react-core";
 
 import { DocumentMetadata } from "@app/components/DocumentMetadata";
-import { Paths, useRouteParams } from "@app/Routes";
+import { Paths } from "@app/Constants";
+import { useRouteParams } from "@app/hooks/useRouteParams";
 import { useFetchRekorEntry } from "@app/queries/rekor-search";
 import { Link, useNavigate } from "react-router-dom";
 import { Entry } from "./components/Entry";

--- a/client/src/app/pages/Rekor/RekorSearch/components/RekorList.tsx
+++ b/client/src/app/pages/Rekor/RekorSearch/components/RekorList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Paths } from "@app/Routes";
+import { Paths } from "@app/Constants";
 import { FilterToolbar } from "@app/components/FilterToolbar/FilterToolbar";
 import { MultiselectFilterControl } from "@app/components/FilterToolbar/MultiselectFilterControl";
 import { SearchFilterControl } from "@app/components/FilterToolbar/SearchFilterControl";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,7 +42,6 @@ export default defineConfig([
       "@typescript-eslint/no-inferrable-types": "off",
       "@typescript-eslint/restrict-template-expressions": "off",
       "react-hooks/rules-of-hooks": "off",
-      "react-refresh/only-export-components": "off",
       "@eslint-react/no-create-ref": "off",
       "@eslint-react/no-leaked-conditional-rendering": "off",
       "@eslint-react/unsupported-syntax": "off",


### PR DESCRIPTION
> **Tracking issue:** https://github.com/securesign/rhtas-console-ui/issues/307
> **Task:** Task 10 — React refresh export constraints

---

## Summary

Enable `react-refresh/only-export-components` by fixing all 3 violations:

**Routes.tsx** (2 violations) — split mixed exports:
- Moved `Paths` constant to `Constants.ts` (existing file, appropriate location)
- Extracted `useRouteParams` hook to `client/src/app/hooks/useRouteParams.ts`
- Updated 3 import sites: `sidebar.tsx`, `RekorEntry.tsx`, `RekorList.tsx`
- `Routes.tsx` now only exports `AppRoutes`

**useFeatureFlags.tsx** (1 violation) — provider + hook co-location is intentional:
- Added inline `eslint-disable` with explanation

## Test plan

- [x] `npm run lint` passes with zero warnings/errors
- [x] `npm run test` — all 41 test files pass (422 tests)
- [x] `npm run build` — production build succeeds
- [ ] Verify navigation and route params still work in the UI