### PR TITLE
ci: enable Konflux pipeline for GitHub merge queue

### DIFF
--- a/.tekton/rhtas-console-ui-pull-request.yaml
+++ b/.tekton/rhtas-console-ui-pull-request.yaml
@@ -8,12 +8,15 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      (event == "pull_request" && target_branch == "main") ||
+      (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhtas-console
     appstudio.openshift.io/component: rhtas-console-ui
     pipelines.appstudio.openshift.io/type: build
+    release.appstudio.openshift.io/auto-release: "false"
   name: rhtas-console-ui-on-pull-request
   namespace: rhtas-tenant
 spec:


### PR DESCRIPTION
## Objective
Set the Konflux builds as a mandatory "required" build to pass within the github action rules. If Konflux does not pass then a PR cannot be merged.

## Problem

The Konflux pipeline (`rhtas-console-ui-on-pull-request`) only triggers on `pull_request` events. GitHub's merge queue creates temporary branches (`gh-readonly-queue/main/...`) and sends `push` events — not `pull_request` events — so Konflux never runs on merge queue entries.

This blocks adding `Red Hat Konflux / rhtas-console-ui-on-pull-request` as a required status check, because the check would never report a result in the merge queue and the queue would always time out.

## Solution

### CEL expression update

Expand the PipelinesAsCode CEL expression to also trigger on push events to merge queue branches:

```yaml
pipelinesascode.tekton.dev/on-cel-expression: >-
  (event == "pull_request" && target_branch == "main") ||
  (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
```

This follows the official [Konflux GitHub Merge Queues documentation](https://konflux-ci.dev/docs/patterns/github-merge-queues/).

### Auto-release prevention

Add `release.appstudio.openshift.io/auto-release: "false"` label to prevent snapshot builds from merge queue branches being released accidentally, as recommended by the Konflux docs.

## Manual follow-up

After merging, add `Red Hat Konflux / rhtas-console-ui-on-pull-request` as a required status check in the GitHub ruleset (Settings > Rules > Rulesets).

## References

- Konflux — GitHub Merge Queues: https://konflux-ci.dev/docs/patterns/github-merge-queues/
- GitHub — Managing a merge queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
