### PR TITLE
Revert "chore(deps): bump vite from 8.1.2 to 8.1.3 in the tools group across 1 directory"

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -56,7 +56,7 @@
     "@vitest/browser": "^4.1.9",
     "jsdom": "^28.0.0",
     "typescript": "~6.0.3",
-    "vite": "^8.1.3",
+    "vite": "^8.0.0",
     "vite-plugin-ejs": "^2.0.0",
     "vite-plugin-istanbul": "^9.0.1",
     "vite-plugin-static-copy": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "@vitest/browser": "^4.1.9",
         "jsdom": "^28.0.0",
         "typescript": "~6.0.3",
-        "vite": "^8.1.3",
+        "vite": "^8.0.0",
         "vite-plugin-ejs": "^2.0.0",
         "vite-plugin-istanbul": "^9.0.1",
         "vite-plugin-static-copy": "^4.1.0",
@@ -6913,6 +6913,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -11684,9 +11703,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -12323,25 +12342,6 @@
         "ejs": ">=5.0.1",
         "express": "^5.1.0",
         "http-terminator": "^3.2.0"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     }
   }


### PR DESCRIPTION
Reverts securesign/rhtas-console-ui#323 because it introduced a dependency that is not available in Konflux yet therefore breaking it

We won't have these issue (hopefully) any longer after we merge https://github.com/securesign/rhtas-console-ui/pull/327