### PR TITLE
chore: convert /server to typescript and add tc checker to all package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf ./dist",
     "clean:all": "rimraf ./dist ./node_modules",
     "build": "npm run generate && tsc -b && vite build",
-    "lint": "eslint --max-warnings 0 .",
+    "lint": "eslint --max-warnings 0 . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "format": "prettier --check --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",
     "format:fix": "prettier --write --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",

--- a/common/package.json
+++ b/common/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "clean:all": "rimraf ./dist ./node_modules",
-    "lint": "eslint --max-warnings 0 .",
+    "lint": "eslint --max-warnings 0 . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "format": "prettier --check --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",
     "format:fix": "prettier --write --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,7 +6,7 @@
     "clean": "rimraf ./test-results ./playwright-report",
     "clean:all": "rimraf ./dist ./node_modules",
     "codegen": "npx playwright codegen http://localhost:3000",
-    "lint": "eslint .",
+    "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "format": "prettier --check './tests/**/*.{ts,tsx,js,json}'",
     "format:fix": "prettier --write './tests/**/*.{ts,tsx,js,json}'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3366,6 +3366,13 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "license": "MIT"
     },
+    "node_modules/@types/ejs": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.5.tgz",
+      "integrity": "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -12315,6 +12322,9 @@
         "ejs": ">=5.0.1",
         "express": "^5.1.0",
         "http-terminator": "^3.2.0"
+      },
+      "devDependencies": {
+        "@types/ejs": "^3.1.5"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "clean:all": "rimraf ./dist ./node_modules",
-    "lint": "eslint .",
+    "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "format": "prettier --check './src/**/*.{ts,tsx,js,json}'",
     "format:fix": "prettier --write './src/**/*.{ts,tsx,js,json}'",
@@ -20,5 +20,8 @@
     "ejs": ">=5.0.1",
     "express": "^5.1.0",
     "http-terminator": "^3.2.0"
+  },
+  "devDependencies": {
+    "@types/ejs": "^3.1.5"
   }
 }

--- a/server/rollup.config.js
+++ b/server/rollup.config.js
@@ -4,6 +4,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import run from "@rollup/plugin-run";
+import typescript from "@rollup/plugin-typescript";
 
 const buildAndRun = process.env?.ROLLUP_RUN === "true";
 
@@ -11,7 +12,7 @@ const buildAndRun = process.env?.ROLLUP_RUN === "true";
 export default {
   strictDeprecations: true,
 
-  input: "src/index.js",
+  input: "src/index.ts",
   output: {
     file: "dist/index.js",
     format: "esm",
@@ -22,6 +23,7 @@ export default {
   },
 
   plugins: [
+    typescript({ compilerOptions: { rootDir: "src", outDir: "dist" } }),
     nodeResolve({
       preferBuiltins: true,
     }),
@@ -29,7 +31,7 @@ export default {
     json(),
     buildAndRun &&
       run({
-        execArgv: ["-r", "source-map-support/register"],
+        execArgv: ["--enable-source-maps"],
       }),
   ],
 };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,3 @@
-/* global process */
-
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -9,28 +7,28 @@ import { createProxyMiddleware } from "http-proxy-middleware";
 import { createHttpTerminator } from "http-terminator";
 
 import { SERVER_ENV_KEYS, CONSOLE_ENV, brandingStrings, encodeEnv } from "@console-ui/common";
-import proxies from "./proxies";
+import { proxyMap } from "./proxies.js";
 
 const debugMode = process.env.DEBUG === "1";
-debugMode && console.log("CONSOLE_ENV", CONSOLE_ENV);
+if (debugMode) console.log("CONSOLE_ENV", CONSOLE_ENV);
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const pathToClientDist = path.join(__dirname, "../../client/dist");
 
-const port = parseInt(CONSOLE_ENV.PORT, 10) || 8080;
+const port = CONSOLE_ENV.PORT ? Number.parseInt(CONSOLE_ENV.PORT, 10) : 8080;
 
 const app = express();
 app.set("x-powered-by", false);
 
-// Setup proxy handling
-app.use(createProxyMiddleware(proxies.api));
+for (const proxyPath in proxyMap) {
+  app.use(createProxyMiddleware(proxyMap[proxyPath]));
+}
 
 app.engine("ejs", ejs.renderFile);
 app.use(express.json());
 app.set("views", pathToClientDist);
 app.use(express.static(pathToClientDist));
 
-// Handle any request that hasn't already been handled by express.static or proxy
 app.get("*splat", (_, res) => {
   if (CONSOLE_ENV.NODE_ENV === "development") {
     res.send(`
@@ -47,18 +45,16 @@ app.get("*splat", (_, res) => {
   }
 });
 
-// Start the server
 const server = app.listen(port, (error) => {
   if (error) {
-    throw error; // e.g. EADDRINUSE
+    throw error;
   }
   console.log(`Server listening on port::${port}`);
 });
 
-// Handle shutdown signals Ctrl-C (SIGINT) and default podman/docker stop (SIGTERM)
 const httpTerminator = createHttpTerminator({ server });
 
-const shutdown = async (signal) => {
+const shutdown = async (signal: string) => {
   if (!server) {
     console.log(`${signal}, no server running.`);
     return;

--- a/server/src/proxies.ts
+++ b/server/src/proxies.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs";
-import path from "node:path";
 import https from "node:https";
+import path from "node:path";
+
+import type { Options } from "http-proxy-middleware";
+
 import { CONSOLE_ENV } from "@console-ui/common";
 
-/** @type Logger */
 const logger =
   process.env.DEBUG === "1"
     ? console
@@ -13,25 +15,22 @@ const logger =
         error: console.error,
       };
 
-// Configure HTTPS agent for proxying to backend API with TLS
 const apiUrl = CONSOLE_ENV.CONSOLE_API_URL ?? "http://localhost:8080";
-let proxyConfig = {
+const proxyConfig: Options = {
   pathFilter: "/api",
   target: apiUrl,
   logger,
   changeOrigin: true,
 };
 
-// When backend uses HTTPS, load CA certificates from SSL_CERT_DIR
 if (apiUrl.startsWith("https://")) {
   const sslCertDir = process.env.SSL_CERT_DIR;
 
   if (sslCertDir && sslCertDir.trim()) {
     const caPaths = sslCertDir.split(":");
-    const cas = [];
+    const cas: Buffer[] = [];
 
     for (const dir of caPaths) {
-      // Try to read as directory first
       try {
         const files = fs.readdirSync(dir);
         for (const file of files) {
@@ -41,23 +40,23 @@ if (apiUrl.startsWith("https://")) {
               const cert = fs.readFileSync(certPath);
               cas.push(cert);
               logger.info(`Loaded CA certificate from ${certPath}`);
-            } catch (error) {
-              logger.warn(`Failed to load certificate ${certPath}: ${error.message}`);
+            } catch (error: unknown) {
+              logger.warn(`Failed to load certificate ${certPath}: ${(error as NodeJS.ErrnoException).message}`);
             }
           }
         }
-      } catch (error) {
-        // If not a directory, try to read as a single file
-        if (error.code === "ENOTDIR" || error.code === "ENOENT") {
+      } catch (error: unknown) {
+        const nodeError = error as NodeJS.ErrnoException;
+        if (nodeError.code === "ENOTDIR" || nodeError.code === "ENOENT") {
           try {
             const cert = fs.readFileSync(dir);
             cas.push(cert);
             logger.info(`Loaded CA certificate from ${dir}`);
-          } catch (readError) {
-            logger.warn(`Failed to load CAs from ${dir}: ${readError.message}`);
+          } catch (readError: unknown) {
+            logger.warn(`Failed to load CAs from ${dir}: ${(readError as NodeJS.ErrnoException).message}`);
           }
         } else {
-          logger.warn(`Failed to read directory ${dir}: ${error.message}`);
+          logger.warn(`Failed to read directory ${dir}: ${nodeError.message}`);
         }
       }
     }
@@ -73,6 +72,6 @@ if (apiUrl.startsWith("https://")) {
   }
 }
 
-export default {
+export const proxyMap: Record<string, Options> = {
   api: proxyConfig,
 };

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+
+  "include": ["src/**/*"],
+
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2021",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
+    "allowJs": true,
+    "sourceMap": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,5 @@
     "strict": true
   },
   "files": [],
-  "references": [
-    { "path": "./client" },
-    { "path": "./common" },
-    { "path": "./e2e" }
-  ]
+  "references": [{ "path": "./client" }, { "path": "./common" }, { "path": "./e2e" }, { "path": "./server" }]
 }


### PR DESCRIPTION
- Make the "/server" directory to use typescript instead of plan javascript
- Include `tsc --noEmit` into all package.json files to verify Typescript check during linting
