### PR TITLE
chore: use tsconfig.app.json in client ts check

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf ./dist",
     "clean:all": "rimraf ./dist ./node_modules",
     "build": "npm run generate && tsc -b && vite build",
-    "lint": "eslint --max-warnings 0 . && tsc --noEmit",
+    "lint": "eslint --max-warnings 0 . && tsc --noEmit -p tsconfig.app.json",
     "lint:fix": "eslint . --fix",
     "format": "prettier --check --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",
     "format:fix": "prettier --write --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",


### PR DESCRIPTION
## Summary
- `client/package.json` now uses `-p tsconfig.app.json` otherwise the typescript checks in the client won't be triggered

I discovered that in the case of the `client/` directory it is not enough to point to the default `tsconfig.json`. 
This repository didn't find any typescript errors but doing similar configuration this other repository found typescript errors https://github.com/guacsec/trustify-ui/pull/1156 . Which proves that `-p tsconfig.app.json` was needed

