### PR TITLE
feat: display all roles in TUF metadata tab

### DIFF
--- a/client/openapi/console.yaml
+++ b/client/openapi/console.yaml
@@ -221,12 +221,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /api/v1/trust/root-metadata-info:
+  /api/v1/trust/metadata-info:
     get:
-      summary: Get TUF Root Metadata
+      summary: Get TUF Metadata Info
       description: |
-        Retrieves metadata information about the TUF root versions from the trust repository.
-        This includes metadata versioning, expiration timestamps, and current status (e.g., valid or expired).
+        Retrieves metadata information for all TUF roles (root, targets, snapshot, timestamp)
+        from the trust repository. Each role includes versioning, expiration timestamps,
+        and current status (e.g., valid, expiring, or expired).
       tags:
         - Trust
       parameters:
@@ -239,11 +240,11 @@ paths:
             example: https://tuf-repo-cdn.sigstore.dev/
       responses:
         "200":
-          description: List of TUF root metadata entries
+          description: TUF metadata info grouped by role
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RootMetadataInfoList"
+                $ref: "#/components/schemas/MetadataInfoResponse"
         "400":
           description: Invalid input
           content:
@@ -684,32 +685,35 @@ components:
         - registry
         - metadata
         - digest
-    RootMetadataInfo:
+    MetadataInfo:
       type: object
       properties:
         version:
           type: string
-          description: Version of the TUF root metadata
+          description: Version of the TUF metadata
         expires:
           type: string
-          description: Expiry date of the TUF root metadata
+          description: Expiry date of the TUF metadata
         status:
           type: string
-          description: Status of the TUF root metadata
+          description: Status of the TUF metadata (valid, expiring, expired)
       required:
         - version
         - expires
         - status
-    RootMetadataInfoList:
+    MetadataInfoResponse:
       type: object
       properties:
         repo-url:
           type: string
           description: URL of the TUF repository
         data:
-          type: array
-          items:
-            $ref: "#/components/schemas/RootMetadataInfo"
+          type: object
+          description: Metadata info grouped by TUF role (root, targets, snapshot, timestamp)
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/MetadataInfo"
       required:
         - data
     TargetsList:
@@ -748,6 +752,19 @@ components:
         - type
         - status
         - content
+    CertificateStatus:
+      type: string
+      description: >
+        Status of the certificate, derived from trusted_root.json validFor window and X.509 validity.
+        active — in service, cert is valid.
+        expiring — in service, cert expires within 30 days.
+        expired — the X.509 cert has actually expired.
+        revoked — cert still valid but taken out of service.
+      enum:
+        - active
+        - expiring
+        - expired
+        - revoked
     CertificateInfo:
       type: object
       properties:
@@ -761,18 +778,7 @@ components:
           type: string
           description: Target type
         status:
-          type: string
-          description: >
-            Status of the certificate, derived from trusted_root.json validFor window and X.509 validity.
-            active — in service, cert is valid.
-            expiring — in service, cert expires within 30 days.
-            expired — the X.509 cert has actually expired.
-            revoked — cert still valid but taken out of service.
-          enum:
-            - active
-            - expiring
-            - expired
-            - revoked
+          $ref: "#/components/schemas/CertificateStatus"
         target:
           type: string
           description: The TUF target to which the certificate is associated.

--- a/client/src/app/pages/TrustRoot/TrustRoot.tsx
+++ b/client/src/app/pages/TrustRoot/TrustRoot.tsx
@@ -3,7 +3,7 @@ import React, { Fragment } from "react";
 import { Content, PageSection, Tab, TabContent, Tabs, TabTitleText } from "@patternfly/react-core";
 import { ExternalLinkAltIcon } from "@patternfly/react-icons";
 
-import { useFetchTrustRootMetadataInfo, useFetchTrustTargetCertificates } from "@app/queries/trust";
+import { useFetchTrustMetadataInfo, useFetchTrustTargetCertificates } from "@app/queries/trust";
 
 import { CertificatesTable } from "./components/Certificates";
 import { Overview } from "./components/Overview";
@@ -13,11 +13,7 @@ import { DocumentMetadata } from "@app/components/DocumentMetadata";
 import { LoadingWrapper } from "@tsd-ui/core";
 
 export const TrustRoots: React.FC = () => {
-  const {
-    rootMetadataList,
-    isFetching: isFetchingRootMetadata,
-    fetchError: fetchErrorRootMetadata,
-  } = useFetchTrustRootMetadataInfo();
+  const { metadataInfo, isFetching: isFetchingMetadata, fetchError: fetchErrorMetadata } = useFetchTrustMetadataInfo();
 
   const {
     certificates,
@@ -44,8 +40,8 @@ export const TrustRoots: React.FC = () => {
           <h1>Trust Root</h1>
           <p>This information represents the update framework.</p>
           <p>
-            <a href={rootMetadataList?.["repo-url"]} target="_blank" rel="noopener noreferrer">
-              {rootMetadataList?.["repo-url"]} <ExternalLinkAltIcon />
+            <a href={metadataInfo?.["repo-url"]} target="_blank" rel="noopener noreferrer">
+              {metadataInfo?.["repo-url"]} <ExternalLinkAltIcon />
             </a>
           </p>
         </Content>
@@ -72,7 +68,7 @@ export const TrustRoots: React.FC = () => {
           />
           <Tab
             eventKey={2}
-            title={<TabTitleText>Root details</TabTitleText>}
+            title={<TabTitleText>TUF Metadata</TabTitleText>}
             tabContentId="rootDetailsTabSection"
             tabContentRef={rootDetailsTabRef}
           />
@@ -84,7 +80,7 @@ export const TrustRoots: React.FC = () => {
             certificates={certificates?.data ?? []}
             isFetching={isFetchingCertificates}
             fetchError={fetchErrorCertificates}
-            rootLink={rootMetadataList?.["repo-url"]}
+            rootLink={metadataInfo?.["repo-url"]}
           />
         </TabContent>
         <TabContent eventKey={1} id="certificatesTabSection" ref={certificatesTabRef} aria-label="Certificates" hidden>
@@ -94,10 +90,10 @@ export const TrustRoots: React.FC = () => {
             fetchError={fetchErrorCertificates}
           />
         </TabContent>
-        <TabContent eventKey={2} id="rootDetailsTabSection" ref={rootDetailsTabRef} aria-label="Root details" hidden>
-          <LoadingWrapper isFetching={isFetchingRootMetadata} fetchError={fetchErrorRootMetadata}>
-            {rootMetadataList ? (
-              <RootDetails rootMetadataList={rootMetadataList} />
+        <TabContent eventKey={2} id="rootDetailsTabSection" ref={rootDetailsTabRef} aria-label="Metadata" hidden>
+          <LoadingWrapper isFetching={isFetchingMetadata} fetchError={fetchErrorMetadata}>
+            {metadataInfo ? (
+              <RootDetails metadataInfo={metadataInfo} />
             ) : (
               <MetadataNotAvailable errorInfo="No metadata list found" />
             )}

--- a/client/src/app/pages/TrustRoot/components/RootDetails.tsx
+++ b/client/src/app/pages/TrustRoot/components/RootDetails.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import {
+  Bullseye,
   Card,
   CardBody,
   CardTitle,
@@ -8,6 +9,9 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTermHelpText,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
   Gallery,
   GalleryItem,
 } from "@patternfly/react-core";
@@ -46,6 +50,16 @@ export const RootDetails: React.FC<IRootDetailsProps> = ({ metadataInfo }) => {
       latest: getLatestEntry(metadataInfo.data[role]),
     }));
   }, [metadataInfo]);
+
+  if (roles.length === 0) {
+    return (
+      <Bullseye>
+        <EmptyState variant={EmptyStateVariant.sm} titleText="No metadata available" headingLevel="h4">
+          <EmptyStateBody>No TUF role metadata was found for this repository.</EmptyStateBody>
+        </EmptyState>
+      </Bullseye>
+    );
+  }
 
   return (
     <Gallery hasGutter minWidths={{ default: "300px" }}>

--- a/client/src/app/pages/TrustRoot/components/RootDetails.tsx
+++ b/client/src/app/pages/TrustRoot/components/RootDetails.tsx
@@ -8,77 +8,74 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTermHelpText,
-  Stack,
-  StackItem,
+  Gallery,
+  GalleryItem,
 } from "@patternfly/react-core";
 
-import type { RootMetadataInfoList } from "@app/client";
+import type { MetadataInfo, MetadataInfoResponse } from "@app/client";
 import { CertificateStatusIcon } from "@app/components/CertificateStatusIcon";
 import { capitalizeFirstLetter, formatDate } from "@app/utils/utils";
 import { createComparator } from "@tsd-ui/core";
 
 interface IRootDetailsProps {
-  rootMetadataList: RootMetadataInfoList;
+  metadataInfo: MetadataInfoResponse;
 }
 
 const comparator = createComparator();
 
-export const RootDetails: React.FC<IRootDetailsProps> = ({ rootMetadataList }) => {
-  const latestMetadataInfo = React.useMemo(() => {
-    // Sort:desc of metadata by version
-    const metadataInfo = [...rootMetadataList.data].sort((a, b) => comparator(a.version, b.version)).reverse();
-    return metadataInfo[0] ? metadataInfo[0] : null;
-  }, [rootMetadataList]);
+const ROLE_LABELS: Record<string, string> = {
+  root: "Root",
+  targets: "Targets",
+  snapshot: "Snapshot",
+  timestamp: "Timestamp",
+};
+
+const ROLE_ORDER = ["root", "targets", "snapshot", "timestamp"];
+
+function getLatestEntry(entries: MetadataInfo[]): MetadataInfo | null {
+  if (!entries || entries.length === 0) return null;
+  const sorted = [...entries].sort((a, b) => comparator(a.version, b.version)).reverse();
+  return sorted[0] ?? null;
+}
+
+export const RootDetails: React.FC<IRootDetailsProps> = ({ metadataInfo }) => {
+  const roles = React.useMemo(() => {
+    return ROLE_ORDER.filter((role) => metadataInfo.data[role]?.length).map((role) => ({
+      key: role,
+      label: ROLE_LABELS[role] ?? role,
+      latest: getLatestEntry(metadataInfo.data[role]),
+    }));
+  }, [metadataInfo]);
 
   return (
-    <Stack>
-      <StackItem>
-        <Card isPlain>
-          <CardTitle>Root details</CardTitle>
-          <CardBody>
-            <DescriptionList
-              aria-label="Metadata"
-              columnModifier={{
-                default: "2Col",
-              }}
-            >
-              <DescriptionListGroup>
-                <DescriptionListTermHelpText>Type</DescriptionListTermHelpText>
-                <DescriptionListDescription>tuf</DescriptionListDescription>
-              </DescriptionListGroup>
-            </DescriptionList>
-          </CardBody>
-        </Card>
-      </StackItem>
-      <StackItem>
-        <Card isPlain>
-          <CardTitle>Metadata</CardTitle>
-          <CardBody>
-            <DescriptionList
-              aria-label="Metadata"
-              columnModifier={{
-                default: "2Col",
-              }}
-            >
-              <DescriptionListGroup>
-                <DescriptionListTermHelpText>Version</DescriptionListTermHelpText>
-                <DescriptionListDescription>{latestMetadataInfo?.version}</DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTermHelpText>Expires</DescriptionListTermHelpText>
-                <DescriptionListDescription>{formatDate(latestMetadataInfo?.expires)}</DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTermHelpText>Status</DescriptionListTermHelpText>
-                <DescriptionListDescription>
-                  {latestMetadataInfo && <CertificateStatusIcon status={latestMetadataInfo?.status} />}{" "}
-                  {capitalizeFirstLetter(latestMetadataInfo?.status ?? "")}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-            </DescriptionList>
-          </CardBody>
-        </Card>
-      </StackItem>
-    </Stack>
+    <Gallery hasGutter minWidths={{ default: "300px" }}>
+      {roles.map(({ key, label, latest }) => (
+        <GalleryItem key={key}>
+          <Card isFullHeight>
+            <CardTitle>{label}</CardTitle>
+            <CardBody>
+              {latest ? (
+                <DescriptionList aria-label={`${label} metadata`}>
+                  <DescriptionListGroup>
+                    <DescriptionListTermHelpText>Version</DescriptionListTermHelpText>
+                    <DescriptionListDescription>{latest.version}</DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTermHelpText>Expires</DescriptionListTermHelpText>
+                    <DescriptionListDescription>{formatDate(latest.expires)}</DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTermHelpText>Status</DescriptionListTermHelpText>
+                    <DescriptionListDescription>
+                      <CertificateStatusIcon status={latest.status} /> {capitalizeFirstLetter(latest.status)}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                </DescriptionList>
+              ) : null}
+            </CardBody>
+          </Card>
+        </GalleryItem>
+      ))}
+    </Gallery>
   );
 };

--- a/client/src/app/queries/mocks/trust.mock.ts
+++ b/client/src/app/queries/mocks/trust.mock.ts
@@ -1,4 +1,4 @@
-import type { CertificateInfoList, RootMetadataInfoList, TrustConfig } from "@app/client";
+import type { CertificateInfoList, MetadataInfoResponse, TrustConfig } from "@app/client";
 
 export const trustConfigMock: TrustConfig = {
   fulcioCertAuthorities: [
@@ -9,25 +9,18 @@ export const trustConfigMock: TrustConfig = {
   ],
 };
 
-export const trustRootMetadataInfoMock: RootMetadataInfoList = {
+export const trustMetadataInfoMock: MetadataInfoResponse = {
   "repo-url": "https://tuf-repo-cdn.sigstore.dev",
-  data: [
-    {
-      expires: "2025-02-19T08:04:32Z",
-      status: "expired",
-      version: "1",
-    },
-    {
-      expires: "2025-08-05T08:37:20Z",
-      status: "expiring",
-      version: "2",
-    },
-    {
-      expires: "2026-01-22T13:05:59Z",
-      status: "valid",
-      version: "3",
-    },
-  ],
+  data: {
+    root: [
+      { expires: "2026-11-20T13:58:18Z", status: "valid", version: "3" },
+      { expires: "2025-02-19T08:04:32Z", status: "expired", version: "1" },
+      { expires: "2025-08-05T08:37:20Z", status: "expired", version: "2" },
+    ],
+    targets: [{ expires: "2036-05-09T09:00:52Z", status: "valid", version: "14" }],
+    snapshot: [{ expires: "2036-05-15T08:09:16Z", status: "valid", version: "165" }],
+    timestamp: [{ expires: "2026-07-30T08:02:24Z", status: "expiring", version: "736" }],
+  },
 };
 
 export const trustTargetCertificatesMock: CertificateInfoList = {

--- a/client/src/app/queries/trust.test.tsx
+++ b/client/src/app/queries/trust.test.tsx
@@ -20,13 +20,13 @@ vi.mock("@app/client", async () => {
   return {
     ...actual,
     getApiV1TrustConfig: vi.fn(),
-    getApiV1TrustRootMetadataInfo: vi.fn(),
+    getApiV1TrustMetadataInfo: vi.fn(),
     getApiV1TrustTargetsCertificates: vi.fn(),
   };
 });
 
-import { useFetchTrustConfig, useFetchTrustRootMetadataInfo, useFetchTrustTargetCertificates, TrustKey } from "./trust";
-import { trustConfigMock, trustRootMetadataInfoMock, trustTargetCertificatesMock } from "./mocks/trust.mock";
+import { useFetchTrustConfig, useFetchTrustMetadataInfo, useFetchTrustTargetCertificates, TrustKey } from "./trust";
+import { trustConfigMock, trustMetadataInfoMock, trustTargetCertificatesMock } from "./mocks/trust.mock";
 
 describe("Trust Queries", () => {
   let queryClient: QueryClient;
@@ -122,28 +122,28 @@ describe("Trust Queries", () => {
     });
   });
 
-  describe("useFetchTrustRootMetadataInfo", () => {
-    it("should return mock root metadata info", async () => {
-      const { result } = renderHook(() => useFetchTrustRootMetadataInfo(), { wrapper });
+  describe("useFetchTrustMetadataInfo", () => {
+    it("should return mock metadata info", async () => {
+      const { result } = renderHook(() => useFetchTrustMetadataInfo(), { wrapper });
 
       await waitFor(
         () => {
-          expect(result.current.rootMetadataList).toBeDefined();
+          expect(result.current.metadataInfo).toBeDefined();
         },
         { timeout: 2000 },
       );
 
-      expect(result.current.rootMetadataList).toEqual(trustRootMetadataInfoMock);
+      expect(result.current.metadataInfo).toEqual(trustMetadataInfoMock);
       expect(result.current.isFetching).toBe(false);
       expect(result.current.fetchError).toBeNull();
     });
 
     it("should expose refetch function", async () => {
-      const { result } = renderHook(() => useFetchTrustRootMetadataInfo(), { wrapper });
+      const { result } = renderHook(() => useFetchTrustMetadataInfo(), { wrapper });
 
       await waitFor(
         () => {
-          expect(result.current.rootMetadataList).toBeDefined();
+          expect(result.current.metadataInfo).toBeDefined();
         },
         { timeout: 2000 },
       );
@@ -152,44 +152,44 @@ describe("Trust Queries", () => {
     });
 
     it("should handle refetch", async () => {
-      const { result } = renderHook(() => useFetchTrustRootMetadataInfo(), { wrapper });
+      const { result } = renderHook(() => useFetchTrustMetadataInfo(), { wrapper });
 
       await waitFor(
         () => {
-          expect(result.current.rootMetadataList).toBeDefined();
+          expect(result.current.metadataInfo).toBeDefined();
         },
         { timeout: 2000 },
       );
 
-      const initialData = result.current.rootMetadataList;
-      expect(initialData).toEqual(trustRootMetadataInfoMock);
+      const initialData = result.current.metadataInfo;
+      expect(initialData).toEqual(trustMetadataInfoMock);
 
       // Refetch should work
       await result.current.refetch();
 
       await waitFor(
         () => {
-          expect(result.current.rootMetadataList).toBeDefined();
+          expect(result.current.metadataInfo).toBeDefined();
         },
         { timeout: 2000 },
       );
 
-      expect(result.current.rootMetadataList).toEqual(trustRootMetadataInfoMock);
+      expect(result.current.metadataInfo).toEqual(trustMetadataInfoMock);
     });
 
     it("should use correct query key", async () => {
-      const { result } = renderHook(() => useFetchTrustRootMetadataInfo(), { wrapper });
+      const { result } = renderHook(() => useFetchTrustMetadataInfo(), { wrapper });
 
       await waitFor(
         () => {
-          expect(result.current.rootMetadataList).toBeDefined();
+          expect(result.current.metadataInfo).toBeDefined();
         },
         { timeout: 2000 },
       );
 
       // Verify the query is cached with the correct key
       const queryData = queryClient.getQueryData([TrustKey, "metadata"]);
-      expect(queryData).toEqual(trustRootMetadataInfoMock);
+      expect(queryData).toEqual(trustMetadataInfoMock);
     });
   });
 

--- a/client/src/app/queries/trust.ts
+++ b/client/src/app/queries/trust.ts
@@ -3,16 +3,16 @@ import type { AxiosError } from "axios";
 import { client } from "@app/axios-config/apiInit";
 import {
   getApiV1TrustConfig,
-  getApiV1TrustRootMetadataInfo,
+  getApiV1TrustMetadataInfo,
   getApiV1TrustTargetsCertificates,
   type Error as ApiError,
   type CertificateInfoList,
-  type RootMetadataInfoList,
+  type MetadataInfoResponse,
   type TrustConfig,
 } from "@app/client";
 
 import { useMockableQuery } from "./helpers";
-import { trustConfigMock, trustRootMetadataInfoMock, trustTargetCertificatesMock } from "./mocks/trust.mock";
+import { trustConfigMock, trustMetadataInfoMock, trustTargetCertificatesMock } from "./mocks/trust.mock";
 
 export const TrustKey = "Trust";
 
@@ -38,22 +38,22 @@ export const useFetchTrustConfig = () => {
   };
 };
 
-export const useFetchTrustRootMetadataInfo = () => {
-  const { data, isLoading, error, refetch } = useMockableQuery<RootMetadataInfoList | null, AxiosError<ApiError>>(
+export const useFetchTrustMetadataInfo = () => {
+  const { data, isLoading, error, refetch } = useMockableQuery<MetadataInfoResponse | null, AxiosError<ApiError>>(
     {
       queryKey: [TrustKey, "metadata"],
       queryFn: async () => {
-        const response = await getApiV1TrustRootMetadataInfo({
+        const response = await getApiV1TrustMetadataInfo({
           client,
         });
         return response.data ?? null;
       },
     },
-    trustRootMetadataInfoMock,
+    trustMetadataInfoMock,
   );
 
   return {
-    rootMetadataList: data,
+    metadataInfo: data,
     isFetching: isLoading,
     fetchError: error,
     refetch,

--- a/e2e/tests/pages/trust-root/TrustRootPage.ts
+++ b/e2e/tests/pages/trust-root/TrustRootPage.ts
@@ -17,6 +17,6 @@ export class TrustRootPage {
   }
 
   getTabs() {
-    return Tabs.build(this._page, ["Overview", "Certificates", "Root details"]);
+    return Tabs.build(this._page, ["Overview", "Certificates", "TUF Metadata"]);
   }
 }

--- a/e2e/tests/pages/trust-root/accessibility.spec.ts
+++ b/e2e/tests/pages/trust-root/accessibility.spec.ts
@@ -16,9 +16,9 @@ test.describe("Trust Root - Accessibility", () => {
     await runA11yAudit(page, testInfo, { label: "trust-root-certificates" });
   });
 
-  test("Page view: Root details tab", async ({ page }, testInfo) => {
+  test("Page view: TUF Metadata tab", async ({ page }, testInfo) => {
     const trustRootPage = await TrustRootPage.build(page);
-    await trustRootPage.getTabs().select("Root details");
-    await runA11yAudit(page, testInfo, { label: "trust-root-root-details" });
+    await trustRootPage.getTabs().select("TUF Metadata");
+    await runA11yAudit(page, testInfo, { label: "trust-root-tuf-metadata" });
   });
 });


### PR DESCRIPTION
Assisted by: Claude Code.

## Summary
<!-- Describe what changed and why -->

Add "TUF Metadata" tab showing version, expiry, and status for all 4 TUF roles in a card gallery layout. Replaces the old "Root details" tab that only displayed root metadata.

## Related Issues
<!-- Fixes #123 or Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [ ] All tests pass (`npm run test`)
- [ ] No lint errors (`npm run lint`)
- [ ] No type errors (TypeScript compiles cleanly)
- [ ] New/changed UI behavior visually verified in browser
- [ ] Mock data updated if API types changed

## Screenshots
<!-- If UI changed, add before/after screenshots -->

<img width="1372" height="473" alt="Screenshot From 2026-07-24 16-49-10" src="https://github.com/user-attachments/assets/759b880f-f4bf-4f1a-87ad-b69ea79e6e7b" />
